### PR TITLE
sync pool for scanString buffer and default size changes

### DIFF
--- a/go/vt/sqlparser/token.go
+++ b/go/vt/sqlparser/token.go
@@ -834,11 +834,14 @@ func (tkn *Tokenizer)getScanStringBuf() (*bytes2.Buffer, func()) {
 
 	buffer := bytes2.NewBuffer(tkn.scanStringBuf)
 	closeFunc := func() {
-		tkn.scanStringBuf = tkn.scanStringBuf[len(tkn.scanStringBuf):]
+		bytes := buffer.Bytes()
+		unused := bytes[len(bytes):]
 
-		if cap(tkn.scanStringBuf) < minBufferSize {
-			tkn.scanStringBuf = make([]byte, defaultBufSize)[:0]
+		if cap(unused) < minBufferSize {
+			unused = make([]byte, defaultBufSize)[:0]
 		}
+
+		tkn.scanStringBuf = unused
 	}
 
 	return buffer, closeFunc

--- a/go/vt/sqlparser/token.go
+++ b/go/vt/sqlparser/token.go
@@ -35,7 +35,8 @@ const (
 
 var bufferPool = &sync.Pool{
 	New: func() interface{} {
-		return make([]byte, defaultBufSize)
+		bytes := make([]byte, defaultBufSize)
+		return bytes[:0]
 	},
 }
 
@@ -832,8 +833,12 @@ exit:
 }
 
 func (tkn *Tokenizer) scanString(delim uint16, typ int) (int, []byte) {
-	buffer := bytes2.NewBuffer(bufferPool.Get().([]byte)[:0])
-	defer bufferPool.Put(buffer.Bytes())
+	buffer := bytes2.NewBuffer(bufferPool.Get().([]byte))
+	defer func() {
+		bytes := buffer.Bytes()
+		unused := bytes[len(bytes):]
+		bufferPool.Put(unused)
+	}()
 
 	for {
 		ch := tkn.lastChar


### PR DESCRIPTION
## Description

`func (tkn *Tokenizer) scanString(delim uint16, typ int) (int, []byte)` decreases small allocations and growSlice calls