### PR TITLE
go/mysql: Make all tests pass on macOS.

### DIFF
--- a/.github/workflows/check_make_parser.yml
+++ b/.github/workflows/check_make_parser.yml
@@ -4,25 +4,19 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
 
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.17
 
     - name: Check out code
       uses: actions/checkout@v1
 
     - name: Get dependencies
       run: |
-        sudo apt-get update
-        sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget
-        sudo service mysql stop
-        sudo service etcd stop
-        sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
-        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
     - name: Run make minimaltools

--- a/.github/workflows/cluster_endtoend.yml
+++ b/.github/workflows/cluster_endtoend.yml
@@ -4,26 +4,19 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
 
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.17
 
     - name: Check out code
       uses: actions/checkout@v1
 
     - name: Get dependencies
       run: |
-        sudo apt-get update
-        sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget
-        sudo apt-get install -f
-        sudo service mysql stop
-        sudo service etcd stop
-        sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
-        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
     - name: Run make minimaltools

--- a/.github/workflows/e2e_race.yml
+++ b/.github/workflows/e2e_race.yml
@@ -4,26 +4,19 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
 
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.17
 
     - name: Check out code
       uses: actions/checkout@v1
 
     - name: Get dependencies
       run: |
-        sudo apt-get update
-        sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget
-        sudo apt-get install -f
-        sudo service mysql stop
-        sudo service etcd stop
-        sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
-        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
     - name: Run make minimaltools

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -4,26 +4,19 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
 
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.12
+        go-version: 1.17
 
     - name: Check out code
       uses: actions/checkout@v1
 
     - name: Get dependencies
       run: |
-        sudo apt-get update
-        sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget ant openjdk-8-jdk
-        sudo apt-get install -f
-        sudo service mysql stop
-        sudo service etcd stop
-        sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
-        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
     - name: Run make minimaltools

--- a/.github/workflows/unit_race.yml
+++ b/.github/workflows/unit_race.yml
@@ -4,25 +4,19 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
 
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.12
+        go-version: 1.17
 
     - name: Check out code
       uses: actions/checkout@v1
 
     - name: Get dependencies
       run: |
-        sudo apt-get update
-        sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git wget
-        sudo service mysql stop
-        sudo service etcd stop
-        sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
-        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
         go mod download
 
     - name: Run make minimaltools

--- a/go/mysql/client.go
+++ b/go/mysql/client.go
@@ -17,6 +17,7 @@ limitations under the License.
 package mysql
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net"
@@ -27,7 +28,6 @@ import (
 	"github.com/dolthub/vitess/go/vt/proto/vtrpc"
 	"github.com/dolthub/vitess/go/vt/vterrors"
 	"github.com/dolthub/vitess/go/vt/vttls"
-	"golang.org/x/net/context"
 )
 
 // connectResult is used by Connect.

--- a/go/mysql/client_test.go
+++ b/go/mysql/client_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package mysql
 
 import (
+	"context"
 	"io/ioutil"
 	"net"
 	"os"
@@ -25,8 +26,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 // assertSQLError makes sure we get the right error.

--- a/go/mysql/client_test.go
+++ b/go/mysql/client_test.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -130,5 +131,9 @@ func TestConnectTimeout(t *testing.T) {
 	ctx = context.Background()
 	_, err = Connect(ctx, params)
 	os.Remove(name)
-	assertSQLError(t, err, CRConnectionError, SSUnknownSQLState, "connection refused", "")
+	if runtime.GOOS == "darwin" {
+		assertSQLError(t, err, CRConnectionError, SSUnknownSQLState, "socket operation on non-socket", "")
+	} else {
+		assertSQLError(t, err, CRConnectionError, SSUnknownSQLState, "connection refused", "")
+	}
 }

--- a/go/mysql/flavor.go
+++ b/go/mysql/flavor.go
@@ -17,6 +17,7 @@ limitations under the License.
 package mysql
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strconv"
@@ -25,7 +26,6 @@ import (
 	"github.com/dolthub/vitess/go/sqltypes"
 	"github.com/dolthub/vitess/go/vt/proto/vtrpc"
 	"github.com/dolthub/vitess/go/vt/vterrors"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/go/mysql/flavor_filepos.go
+++ b/go/mysql/flavor_filepos.go
@@ -17,13 +17,12 @@ limitations under the License.
 package mysql
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
 	"strconv"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 type filePosFlavor struct {

--- a/go/mysql/flavor_mariadb.go
+++ b/go/mysql/flavor_mariadb.go
@@ -18,13 +18,13 @@ limitations under the License.
 package mysql
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"time"
 
 	"github.com/dolthub/vitess/go/vt/proto/vtrpc"
 	"github.com/dolthub/vitess/go/vt/vterrors"
-	"golang.org/x/net/context"
 )
 
 // mariadbFlavor implements the Flavor interface for MariaDB.

--- a/go/mysql/flavor_mysql.go
+++ b/go/mysql/flavor_mysql.go
@@ -17,13 +17,13 @@ limitations under the License.
 package mysql
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"time"
 
 	"github.com/dolthub/vitess/go/vt/proto/vtrpc"
 	"github.com/dolthub/vitess/go/vt/vterrors"
-	"golang.org/x/net/context"
 )
 
 // mysqlFlavor implements the Flavor interface for Mysql.

--- a/go/mysql/handshake_test.go
+++ b/go/mysql/handshake_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package mysql
 
 import (
+	"context"
 	"io/ioutil"
 	"net"
 	"os"
@@ -24,8 +25,6 @@ import (
 	"reflect"
 	"strings"
 	"testing"
-
-	"golang.org/x/net/context"
 
 	"github.com/dolthub/vitess/go/vt/tlstest"
 	"github.com/dolthub/vitess/go/vt/vttls"

--- a/go/mysql/query_benchmark_test.go
+++ b/go/mysql/query_benchmark_test.go
@@ -17,13 +17,12 @@ limitations under the License.
 package mysql
 
 import (
+	"context"
 	"flag"
 	"math/rand"
 	"net"
 	"strings"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 var testReadConnBufferSize = DefaultConnBufferSize

--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -45,6 +45,7 @@ const (
 	versionTLS10      = "TLS10"
 	versionTLS11      = "TLS11"
 	versionTLS12      = "TLS12"
+	versionTLS13      = "TLS13"
 	versionTLSUnknown = "UnknownTLSVersion"
 	versionNoTLS      = "None"
 )
@@ -810,6 +811,8 @@ func tlsVersionToString(version uint16) string {
 		return versionTLS11
 	case tls.VersionTLS12:
 		return versionTLS12
+	case tls.VersionTLS13:
+		return versionTLS13
 	default:
 		return versionTLSUnknown
 	}

--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -768,7 +768,7 @@ func TestClearTextServer(t *testing.T) {
 			t.Fatalf("mysql should have failed but returned: %v", output)
 		}
 	} else {
-		if strings.Contains(output, "No such file or directory") {
+		if strings.Contains(output, "No such file or directory") || strings.Contains(output, "(no such file)") {
 			t.Logf("skipping mysql clear text tests, as the clear text plugin cannot be loaded: %v", err)
 			return
 		}
@@ -842,7 +842,7 @@ func TestDialogServer(t *testing.T) {
 	}
 	sql := "select rows"
 	output, ok := runMysql(t, params, sql)
-	if strings.Contains(output, "No such file or directory") {
+	if strings.Contains(output, "No such file or directory") || strings.Contains(output, "(no such file)") {
 		t.Logf("skipping dialog plugin tests, as the dialog plugin cannot be loaded: %v", err)
 		return
 	}
@@ -952,7 +952,7 @@ func TestTLSServer(t *testing.T) {
 		t.Errorf("Unexpected output for 'ssl echo': %v", results)
 	}
 
-	checkCountForTLSVer(t, versionTLS12, 1)
+	checkCountForTLSVer(t, versionTLS13, 1)
 	checkCountForTLSVer(t, versionNoTLS, 0)
 	conn.Close()
 

--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package mysql
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -26,8 +27,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/dolthub/vitess/go/sqltypes"
 	vtenv "github.com/dolthub/vitess/go/vt/env"

--- a/go/netutil/netutil_test.go
+++ b/go/netutil/netutil_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package netutil
 
 import (
+	"fmt"
 	"math/rand"
 	"net"
 	"testing"
@@ -55,7 +56,7 @@ func testUniformity(t *testing.T, size int, margin float64) {
 	rand.Seed(1)
 	data := make([]*net.SRV, size)
 	for i := 0; i < size; i++ {
-		data[i] = &net.SRV{Target: string('a' + i), Weight: 1}
+		data[i] = &net.SRV{Target: fmt.Sprintf("%c", 'a'+i), Weight: 1}
 	}
 	checkDistribution(t, data, margin)
 }

--- a/go/race/norace.go
+++ b/go/race/norace.go
@@ -1,3 +1,4 @@
+//go:build !race
 // +build !race
 
 /*

--- a/go/race/race.go
+++ b/go/race/race.go
@@ -1,3 +1,4 @@
+//go:build race
 // +build race
 
 /*

--- a/go/vt/logutil/logutil_test.go
+++ b/go/vt/logutil/logutil_test.go
@@ -48,6 +48,10 @@ func TestPurgeByCtime(t *testing.T) {
 	if err := os.MkdirAll(logDir, 0777); err != nil {
 		t.Fatalf("os.MkdirAll: %v", err)
 	}
+	logDir, err := filepath.EvalSymlinks(logDir)
+	if err != nil {
+		t.Fatalf("filepath.EvalSymlinks(logDir): %v", err)
+	}
 	defer os.RemoveAll(logDir)
 
 	now := time.Date(2013, 8, 6, 15, 10, 06, 0, time.Now().Location())
@@ -87,6 +91,10 @@ func TestPurgeByMtime(t *testing.T) {
 	logDir := path.Join(os.TempDir(), fmt.Sprintf("%v-%v", os.Args[0], os.Getpid()))
 	if err := os.MkdirAll(logDir, 0777); err != nil {
 		t.Fatalf("os.MkdirAll: %v", err)
+	}
+	logDir, err := filepath.EvalSymlinks(logDir)
+	if err != nil {
+		t.Fatalf("filepath.EvalSymlinks(logDir): %v", err)
 	}
 	defer os.RemoveAll(logDir)
 	createFileWithMtime := func(filename, mtimeStr string) {

--- a/go/vt/sqlparser/ast_permissions.go
+++ b/go/vt/sqlparser/ast_permissions.go
@@ -50,10 +50,10 @@ func (ar *AccountRename) String() string {
 
 // Authentication represents an account's authentication.
 type Authentication struct {
-	RandomPassword   bool
-	Password         string
-	Identity         string
-	Plugin           string
+	RandomPassword bool
+	Password       string
+	Identity       string
+	Plugin         string
 }
 
 // String returns this Authentication as a formatted string.
@@ -108,6 +108,7 @@ func (awa *AccountWithAuth) String() string {
 
 // TLSOptionItemType defines the type that a TLSOptionItem represents.
 type TLSOptionItemType byte
+
 const (
 	TLSOptionItemType_SSL TLSOptionItemType = iota
 	TLSOptionItemType_X509
@@ -124,10 +125,10 @@ type TLSOptionItem struct {
 
 // TLSOptions represents a new user's TLS options.
 type TLSOptions struct {
-	SSL bool
-	X509 bool
-	Cipher string
-	Issuer string
+	SSL     bool
+	X509    bool
+	Cipher  string
+	Issuer  string
 	Subject string
 }
 
@@ -194,6 +195,7 @@ func (tls *TLSOptions) String() string {
 
 // AccountLimitItemType defines the type that an AccountLimitItem represents.
 type AccountLimitItemType byte
+
 const (
 	AccountLimitItemType_Queries_PH AccountLimitItemType = iota
 	AccountLimitItemType_Updates_PH
@@ -209,10 +211,10 @@ type AccountLimitItem struct {
 
 // AccountLimits represents a new user's maximum limits.
 type AccountLimits struct {
-	MaxQueriesPerHour *SQLVal
-	MaxUpdatesPerHour *SQLVal
+	MaxQueriesPerHour     *SQLVal
+	MaxUpdatesPerHour     *SQLVal
 	MaxConnectionsPerHour *SQLVal
-	MaxUserConnections *SQLVal
+	MaxUserConnections    *SQLVal
 }
 
 // NewAccountLimits returns a new AccountLimits from the given items.
@@ -257,6 +259,7 @@ func (al *AccountLimits) String() string {
 
 // PassLockItemType defines the type that a PassLockItem represents.
 type PassLockItemType byte
+
 const (
 	PassLockItemType_PassExpireDefault PassLockItemType = iota
 	PassLockItemType_PassExpireNever
@@ -360,6 +363,7 @@ func (po *PasswordOptions) String() string {
 
 // PrivilegeType is the type of privilege that is being granted or revoked.
 type PrivilegeType byte
+
 const (
 	PrivilegeType_All PrivilegeType = iota
 	PrivilegeType_Insert
@@ -372,6 +376,7 @@ const (
 
 // GrantObjectType represents the object type that the GRANT or REVOKE statement will apply to.
 type GrantObjectType byte
+
 const (
 	GrantObjectType_Any GrantObjectType = iota
 	GrantObjectType_Table
@@ -381,6 +386,7 @@ const (
 
 // GrantUserAssumptionType is the assumption type that the user executing the GRANT statement will use.
 type GrantUserAssumptionType byte
+
 const (
 	GrantUserAssumptionType_Default GrantUserAssumptionType = iota
 	GrantUserAssumptionType_None
@@ -391,7 +397,7 @@ const (
 
 // PrivilegeLevel defines the level that a privilege applies to.
 type PrivilegeLevel struct {
-	Database string
+	Database     string
 	TableRoutine string
 }
 
@@ -414,9 +420,9 @@ func (p *PrivilegeLevel) String() string {
 
 // Privilege specifies a privilege to be used in a GRANT or REVOKE statement.
 type Privilege struct {
-	Type PrivilegeType
+	Type        PrivilegeType
 	DynamicName string
-	Columns []string
+	Columns     []string
 }
 
 // String returns the Privilege as a formatted string.
@@ -451,8 +457,8 @@ func (p *Privilege) String() string {
 
 // GrantUserAssumption represents the target user that the user executing the GRANT statement will assume the identity of.
 type GrantUserAssumption struct {
-	Type GrantUserAssumptionType
-	User AccountName
+	Type  GrantUserAssumptionType
+	User  AccountName
 	Roles []AccountName
 }
 
@@ -492,14 +498,14 @@ func (gau *GrantUserAssumption) String() string {
 
 // CreateUser represents the CREATE USER statement.
 type CreateUser struct {
-	IfNotExists bool
-	Users []AccountWithAuth
-	DefaultRoles []AccountName
-	TLSOptions *TLSOptions
-	AccountLimits *AccountLimits
+	IfNotExists     bool
+	Users           []AccountWithAuth
+	DefaultRoles    []AccountName
+	TLSOptions      *TLSOptions
+	AccountLimits   *AccountLimits
 	PasswordOptions *PasswordOptions
-	Locked bool
-	Attribute string
+	Locked          bool
+	Attribute       string
 }
 
 var _ Statement = (*CreateUser)(nil)
@@ -571,7 +577,7 @@ func (r *RenameUser) Format(buf *TrackedBuffer) {
 
 // DropUser represents the DROP USER statement.
 type DropUser struct {
-	IfExists bool
+	IfExists     bool
 	AccountNames []AccountName
 }
 
@@ -649,12 +655,12 @@ func (d *DropRole) Format(buf *TrackedBuffer) {
 
 // GrantPrivilege represents the GRANT...ON...TO statement.
 type GrantPrivilege struct {
-	Privileges []Privilege
-	ObjectType GrantObjectType
-	PrivilegeLevel PrivilegeLevel
-	To []AccountName
+	Privileges      []Privilege
+	ObjectType      GrantObjectType
+	PrivilegeLevel  PrivilegeLevel
+	To              []AccountName
 	WithGrantOption bool
-	As *GrantUserAssumption
+	As              *GrantUserAssumption
 }
 
 var _ Statement = (*GrantPrivilege)(nil)
@@ -699,8 +705,8 @@ func (g *GrantPrivilege) Format(buf *TrackedBuffer) {
 
 // GrantRole represents the GRANT...TO statement.
 type GrantRole struct {
-	Roles []AccountName
-	To []AccountName
+	Roles           []AccountName
+	To              []AccountName
 	WithAdminOption bool
 }
 
@@ -732,8 +738,8 @@ func (g *GrantRole) Format(buf *TrackedBuffer) {
 
 // GrantProxy represents the GRANT PROXY statement.
 type GrantProxy struct {
-	On AccountName
-	To []AccountName
+	On              AccountName
+	To              []AccountName
 	WithGrantOption bool
 }
 
@@ -758,10 +764,10 @@ func (g *GrantProxy) Format(buf *TrackedBuffer) {
 
 // RevokePrivilege represents the REVOKE...ON...FROM statement.
 type RevokePrivilege struct {
-	Privileges []Privilege
-	ObjectType GrantObjectType
+	Privileges     []Privilege
+	ObjectType     GrantObjectType
 	PrivilegeLevel PrivilegeLevel
-	From []AccountName
+	From           []AccountName
 }
 
 var _ Statement = (*RevokePrivilege)(nil)
@@ -822,7 +828,7 @@ func (r *RevokeAllPrivileges) Format(buf *TrackedBuffer) {
 // RevokeRole represents the REVOKE...FROM statement.
 type RevokeRole struct {
 	Roles []AccountName
-	From []AccountName
+	From  []AccountName
 }
 
 var _ Statement = (*RevokeRole)(nil)
@@ -850,7 +856,7 @@ func (r *RevokeRole) Format(buf *TrackedBuffer) {
 
 // RevokeProxy represents the REVOKE PROXY statement.
 type RevokeProxy struct {
-	On AccountName
+	On   AccountName
 	From []AccountName
 }
 
@@ -904,7 +910,7 @@ func (s *ShowGrants) Format(buf *TrackedBuffer) {
 }
 
 // ShowPrivileges represents the SHOW PRIVILEGES statement.
-type ShowPrivileges struct {}
+type ShowPrivileges struct{}
 
 var _ Statement = (*ShowPrivileges)(nil)
 

--- a/go/vt/vterrors/errors_test.go
+++ b/go/vt/vterrors/errors_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vterrors
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -25,7 +26,6 @@ import (
 	"testing"
 
 	vtrpcpb "github.com/dolthub/vitess/go/vt/proto/vtrpc"
-	"golang.org/x/net/context"
 )
 
 func TestWrapNil(t *testing.T) {

--- a/go/vt/vterrors/vterrors.go
+++ b/go/vt/vterrors/vterrors.go
@@ -86,12 +86,12 @@ limitations under the License.
 package vterrors
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"io"
 
 	vtrpcpb "github.com/dolthub/vitess/go/vt/proto/vtrpc"
-	"golang.org/x/net/context"
 )
 
 // LogErrStacks controls whether or not printing errors includes the


### PR DESCRIPTION
Bumps expected TLS version from 1.2 to 1.3.

Adds some string matching for strerror strings that are different between Linux
and macOS.