### PR TITLE
Handle subquery indexes correctly for special MySQL comments

### DIFF
--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -782,6 +782,12 @@ var (
 			input:  "select /*!401011 from*/ t",
 			output: "select 1 from t",
 		}, {
+			input:  "/*! create view a as select 1 as x */",
+			output: "create view a as select 1 as x from dual",
+		}, {
+			input:  "/*!12345 create view a as select 1 as x */",
+			output: "create view a as select 1 as x from dual",
+		}, {
 			input: "select /* dual */ 1 from dual",
 		}, {
 			input:  "select * from (select 'tables') tables",

--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -2685,6 +2685,36 @@ func TestCreateViewSelectPosition(t *testing.T) {
 	}, {
 		query: "create view a as select /* comment */ 2 + 2 from dual",
 		sel:   "select /* comment */ 2 + 2 from dual",
+	}, {
+		query: "/*! create view a as select 2 from dual */",
+		sel:   "select 2 from dual",
+	}, {
+		query: "/*!12345 create view a as select 2 from dual */",
+		sel:   "select 2 from dual",
+	}}
+	for _, tcase := range cases {
+		tree, err := Parse(tcase.query)
+		if err != nil {
+			t.Errorf("Parse(%q) err: %v", tcase.query, err)
+		}
+		ddl, ok := tree.(*DDL)
+		if !ok {
+			t.Errorf("Expected DDL when parsing (%q)", tcase.query)
+		}
+		sel := tcase.query[ddl.SubStatementPositionStart:ddl.SubStatementPositionEnd]
+		if sel != tcase.sel {
+			t.Errorf("expected select to be %q, got %q", tcase.sel, sel)
+		}
+	}
+}
+
+func TestCreateViewSelectPosition1(t *testing.T) {
+	cases := []struct {
+		query string
+		sel   string
+	}{{
+		query: "/*!12345 create view a as select 2 from dual */",
+		sel:   "select 2 from dual",
 	}}
 	for _, tcase := range cases {
 		tree, err := Parse(tcase.query)

--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -2691,6 +2691,9 @@ func TestCreateViewSelectPosition(t *testing.T) {
 	}, {
 		query: "/*!12345 create view a as select 2 from dual */",
 		sel:   "select 2 from dual",
+	}, {
+		query: "/*!50001 CREATE VIEW `some_view` as SELECT 1 AS `x`*/",
+		sel:   "SELECT 1 AS `x`",
 	}}
 	for _, tcase := range cases {
 		tree, err := Parse(tcase.query)

--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -2711,30 +2711,6 @@ func TestCreateViewSelectPosition(t *testing.T) {
 	}
 }
 
-func TestCreateViewSelectPosition1(t *testing.T) {
-	cases := []struct {
-		query string
-		sel   string
-	}{{
-		query: "/*!12345 create view a as select 2 from dual */",
-		sel:   "select 2 from dual",
-	}}
-	for _, tcase := range cases {
-		tree, err := Parse(tcase.query)
-		if err != nil {
-			t.Errorf("Parse(%q) err: %v", tcase.query, err)
-		}
-		ddl, ok := tree.(*DDL)
-		if !ok {
-			t.Errorf("Expected DDL when parsing (%q)", tcase.query)
-		}
-		sel := tcase.query[ddl.SubStatementPositionStart:ddl.SubStatementPositionEnd]
-		if sel != tcase.sel {
-			t.Errorf("expected select to be %q, got %q", tcase.sel, sel)
-		}
-	}
-}
-
 // Ensure there is no corruption from using a pooled yyParserImpl in Parse.
 func TestValidParallel(t *testing.T) {
 	validSQL = append(validSQL, validMultiStatementSql...)

--- a/go/vt/sqlparser/token.go
+++ b/go/vt/sqlparser/token.go
@@ -614,8 +614,7 @@ func (tkn *Tokenizer) Scan() (int, []byte) {
 		specialComment := tkn.specialComment
 		tok, val := specialComment.Scan()
 		if tok != 0 {
-			// TODO: might need to adjust a bit for /*!
-			// Copy over position from specialComment
+			// Copy over position from specialComment and add offset
 			tkn.Position = tkn.specialPosOffset + specialComment.Position
 			// return the specialComment scan result as the result
 			return tok, val
@@ -1066,8 +1065,8 @@ func (tkn *Tokenizer) scanMySQLSpecificComment() (int, []byte) {
 		tkn.consumeNext(buffer)
 	}
 	_, sql := ExtractMysqlComment(buffer.String())
-	tkn.specialPosOffset = strings.Index(string(tkn.buf), sql)
 	tkn.specialComment = NewStringTokenizer(sql)
+	tkn.specialPosOffset = strings.Index(string(tkn.buf), sql)
 	return tkn.Scan()
 }
 

--- a/go/vt/sqlparser/token.go
+++ b/go/vt/sqlparser/token.go
@@ -1051,7 +1051,7 @@ func (tkn *Tokenizer) scanMySQLSpecificComment() (int, []byte) {
 	buffer.WriteString("/*!")
 	tkn.next()
 	tkn.specialPosOffset = tkn.Position
-	finished := false
+	foundStartPos := false
 	digitCount := 0
 	for {
 		if tkn.lastChar == '*' {
@@ -1069,7 +1069,7 @@ func (tkn *Tokenizer) scanMySQLSpecificComment() (int, []byte) {
 		tkn.consumeNext(buffer)
 
 		// Already found special comment starting point
-		if finished {
+		if foundStartPos {
 			continue
 		}
 
@@ -1080,7 +1080,7 @@ func (tkn *Tokenizer) scanMySQLSpecificComment() (int, []byte) {
 				digitCount++
 				continue
 			} else {
-				// Provided less than 5 digits (which is already wrong), but force this to move on
+				// Provided less than 5 digits, but force this to move on
 				digitCount = 5
 			}
 		}
@@ -1092,7 +1092,7 @@ func (tkn *Tokenizer) scanMySQLSpecificComment() (int, []byte) {
 
 		// Found start of subexpression
 		tkn.specialPosOffset = tkn.Position - 1
-		finished = true
+		foundStartPos = true
 	}
 	_, sql := ExtractMysqlComment(buffer.String())
 	tkn.specialComment = NewStringTokenizer(sql)


### PR DESCRIPTION
Fix for: https://github.com/dolthub/dolt/issues/2980

When `Tokenizer` detects a special MySQL comment, it just creates a new Tokenizer and embeds it in the old one under the `specialComment` member variable.

This "inner" Tokenizer is then used to handle all the parsing, and its results are just passed to the outer Tokenizer. However, the issue is that the lexer or whatever only reads the `Position` member variable from the outermost Tokenizer.

So my proposed fix is to just copy over the `Position` of the inner Tokenizer to the outer one (with an offset to handle the leading `/*![12345]`. I think a better fix might be to just replace the old Tokenizer with the one we create for `specialComment`?