### PR TITLE
Remove all package-level flags

### DIFF
--- a/go/mysql/auth_server_clientcert.go
+++ b/go/mysql/auth_server_clientcert.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dolthub/vitess/go/vt/log"
 )
 
-var clientcertAuthMethod = flag.String("mysql_clientcert_auth_method", MysqlClearPassword, "client-side authentication method to use. Supported values: mysql_clear_password, dialog.")
+var clientcertAuthMethod = MysqlClearPassword
 
 type AuthServerClientCert struct {
 	Method string
@@ -36,11 +36,11 @@ func InitAuthServerClientCert() {
 		log.Info("Not configuring AuthServerClientCert because mysql_server_ssl_ca is empty")
 		return
 	}
-	if *clientcertAuthMethod != MysqlClearPassword && *clientcertAuthMethod != MysqlDialog {
+	if clientcertAuthMethod != MysqlClearPassword && clientcertAuthMethod != MysqlDialog {
 		log.Fatalf("Invalid mysql_clientcert_auth_method value: only support mysql_clear_password or dialog")
 	}
 	ascc := &AuthServerClientCert{
-		Method: *clientcertAuthMethod,
+		Method: clientcertAuthMethod,
 	}
 	RegisterAuthServerImpl("clientcert", ascc)
 }

--- a/go/mysql/auth_server_static.go
+++ b/go/mysql/auth_server_static.go
@@ -88,18 +88,18 @@ type AuthServerStaticEntry struct {
 // InitAuthServerStatic Handles initializing the AuthServerStatic if necessary.
 func InitAuthServerStatic() {
 	// Check parameters.
-	if *mysqlAuthServerStaticFile == "" && *mysqlAuthServerStaticString == "" {
+	if mysqlAuthServerStaticFile == "" && mysqlAuthServerStaticString == "" {
 		// Not configured, nothing to do.
 		log.Infof("Not configuring AuthServerStatic, as mysql_auth_server_static_file and mysql_auth_server_static_string are empty")
 		return
 	}
-	if *mysqlAuthServerStaticFile != "" && *mysqlAuthServerStaticString != "" {
+	if mysqlAuthServerStaticFile != "" && mysqlAuthServerStaticString != "" {
 		// Both parameters specified, can only use one.
 		log.Fatalf("Both mysql_auth_server_static_file and mysql_auth_server_static_string specified, can only use one.")
 	}
 
 	// Create and register auth server.
-	RegisterAuthServerStaticFromParams(*mysqlAuthServerStaticFile, *mysqlAuthServerStaticString, *mysqlAuthServerStaticReloadInterval)
+	RegisterAuthServerStaticFromParams(mysqlAuthServerStaticFile, mysqlAuthServerStaticString, mysqlAuthServerStaticReloadInterval)
 }
 
 // NewAuthServerStatic returns a new AuthServerStatic, reading from |file| or

--- a/go/mysql/auth_server_static.go
+++ b/go/mysql/auth_server_static.go
@@ -19,7 +19,6 @@ package mysql
 import (
 	"bytes"
 	"encoding/json"
-	"flag"
 	"net"
 	"os"
 	"os/signal"
@@ -34,9 +33,9 @@ import (
 )
 
 var (
-	mysqlAuthServerStaticFile           = flag.String("mysql_auth_server_static_file", "", "JSON File to read the users/passwords from.")
-	mysqlAuthServerStaticString         = flag.String("mysql_auth_server_static_string", "", "JSON representation of the users/passwords config.")
-	mysqlAuthServerStaticReloadInterval = flag.Duration("mysql_auth_static_reload_interval", 0, "Ticker to reload credentials")
+	mysqlAuthServerStaticFile           string        = ""
+	mysqlAuthServerStaticString         string        = ""
+	mysqlAuthServerStaticReloadInterval time.Duration = 0
 )
 
 const (

--- a/go/mysql/auth_server_static_test.go
+++ b/go/mysql/auth_server_static_test.go
@@ -155,11 +155,11 @@ func TestStaticConfigHUPWithRotation(t *testing.T) {
 		t.Fatalf("couldn't create temp file: %v", err)
 	}
 	defer os.Remove(tmpFile.Name())
-	*mysqlAuthServerStaticFile = tmpFile.Name()
+	mysqlAuthServerStaticFile = tmpFile.Name()
 
-	savedReloadInterval := *mysqlAuthServerStaticReloadInterval
-	defer func() { *mysqlAuthServerStaticReloadInterval = savedReloadInterval }()
-	*mysqlAuthServerStaticReloadInterval = 10 * time.Millisecond
+	savedReloadInterval := mysqlAuthServerStaticReloadInterval
+	defer func() { mysqlAuthServerStaticReloadInterval = savedReloadInterval }()
+	mysqlAuthServerStaticReloadInterval = 10 * time.Millisecond
 
 	oldStr := "str1"
 	jsonConfig := fmt.Sprintf("{\"%s\":[{\"Password\":\"%s\"}]}", oldStr, oldStr)

--- a/go/mysql/query_benchmark_test.go
+++ b/go/mysql/query_benchmark_test.go
@@ -18,7 +18,6 @@ package mysql
 
 import (
 	"context"
-	"flag"
 	"math/rand"
 	"net"
 	"strings"
@@ -26,10 +25,6 @@ import (
 )
 
 var testReadConnBufferSize = DefaultConnBufferSize
-
-func init() {
-	flag.IntVar(&testReadConnBufferSize, "test.read_conn_buffer_size", DefaultConnBufferSize, "buffer size for reads from connections in tests")
-}
 
 const benchmarkQueryPrefix = "benchmark "
 

--- a/go/vt/sqlparser/truncate_query.go
+++ b/go/vt/sqlparser/truncate_query.go
@@ -16,16 +16,12 @@ limitations under the License.
 
 package sqlparser
 
-import (
-	"flag"
-)
-
 var (
 	// TruncateUILen truncate queries in debug UIs to the given length. 0 means unlimited.
-	TruncateUILen = flag.Int("sql-max-length-ui", 512, "truncate queries in debug UIs to the given length (default 512)")
+	TruncateUILen = 512
 
 	// TruncateErrLen truncate queries in error logs to the given length. 0 means unlimited.
-	TruncateErrLen = flag.Int("sql-max-length-errors", 0, "truncate queries in error logs to the given length (default unlimited)")
+	TruncateErrLen = 0
 )
 
 func truncateQuery(query string, max int) string {
@@ -41,12 +37,12 @@ func truncateQuery(query string, max int) string {
 // TruncateForUI is used when displaying queries on various Vitess status pages
 // to keep the pages small enough to load and render properly
 func TruncateForUI(query string) string {
-	return truncateQuery(query, *TruncateUILen)
+	return truncateQuery(query, TruncateUILen)
 }
 
 // TruncateForLog is used when displaying queries as part of error logs
 // to avoid overwhelming logging systems with potentially long queries and
 // bind value data.
 func TruncateForLog(query string) string {
-	return truncateQuery(query, *TruncateErrLen)
+	return truncateQuery(query, TruncateErrLen)
 }

--- a/go/vt/vterrors/vterrors.go
+++ b/go/vt/vterrors/vterrors.go
@@ -87,7 +87,6 @@ package vterrors
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"io"
 
@@ -97,10 +96,6 @@ import (
 // LogErrStacks controls whether or not printing errors includes the
 // embedded stack trace in the output.
 var LogErrStacks bool
-
-func init() {
-	flag.BoolVar(&LogErrStacks, "log_err_stacks", false, "log stack traces for errors")
-}
 
 // New returns an error with the supplied message.
 // New also records the stack trace at the point it was called.


### PR DESCRIPTION
### Summary
This is my attempt to perform a minimally invasive purge of all package-level flags.

I would appreciate some input on:
- whether any of the upstream repos that use this vitess fork will be impacted by these changes
- whether this change should be more invasive (e.g., if you don't use the `AuthServerClientCert` it may be better to remove it entirely rather than just prune the flags)

### Motivation
https://github.com/dolthub/vitess/issues/174

### Testing
I've removed all package-level flags:
```
ryanpbrewster@argon:~/p/g/dolthub-vitess$ rg "flag\.\w"
go/mysql/auth_server_clientcert.go
35:     if flag.CommandLine.Lookup("mysql_server_ssl_ca").Value.String() == "" {
```

The existing tests still pass:
```
ryanpbrewster@argon:~/p/g/dolthub-vitess$ go test go/...
ok      go/ast  (cached)
ok      go/build        (cached)
ok      go/build/constraint     (cached)
ok      go/constant     (cached)
ok      go/doc  (cached)
ok      go/format       (cached)
ok      go/importer     (cached)
ok      go/internal/gccgoimporter       (cached)
ok      go/internal/gcimporter  (cached)
ok      go/internal/srcimporter (cached)
?       go/internal/typeparams  [no test files]
ok      go/parser       (cached)
ok      go/printer      (cached)
ok      go/scanner      (cached)
ok      go/token        (cached)
ok      go/types        (cached)
```