### PR TITLE
Fix int overflow on 32-bit architectures

### DIFF
--- a/go/bucketpool/bucketpool.go
+++ b/go/bucketpool/bucketpool.go
@@ -54,7 +54,7 @@ func New(minSize, maxSize int) *Pool {
 	if maxSize < minSize {
 		panic("maxSize can't be less than minSize")
 	}
-	if maxSize > math.MaxUint32 {
+	if int64(maxSize) > math.MaxUint32 {
 		panic("maxSize can't be greater than MaxUint32")
 	}
 


### PR DESCRIPTION
```py
$ GOARCH=386 GOOS=linux go build ./...
# github.com/dolthub/vitess/go/bucketpool
go/bucketpool/bucketpool.go:57:15: math.MaxUint32 (untyped int constant 4294967295) overflows int
```