### PR TITLE
Backporting client support for `caching_sha2_password` auth

### DIFF
--- a/go/mysql/auth_server.go
+++ b/go/mysql/auth_server.go
@@ -19,7 +19,9 @@ package mysql
 import (
 	"bytes"
 	"crypto/rand"
+	"crypto/rsa"
 	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/hex"
 	"net"
 	"strings"
@@ -244,4 +246,88 @@ func AuthServerNegotiateClearOrDialog(c *Conn, method string) (string, error) {
 	default:
 		return "", vterrors.Errorf(vtrpc.Code_INTERNAL, "unrecognized method: %v", method)
 	}
+}
+
+// ScrambleMysqlNativePassword computes the hash of the password using 4.1+ method.
+//
+// This can be used for example inside a `mysql_native_password` plugin implementation
+// if the backend storage implements storage of plain text passwords.
+func ScrambleMysqlNativePassword(salt, password []byte) []byte {
+	if len(password) == 0 {
+		return nil
+	}
+
+	// stage1Hash = SHA1(password)
+	crypt := sha1.New()
+	crypt.Write(password)
+	stage1 := crypt.Sum(nil)
+
+	// scrambleHash = SHA1(salt + SHA1(stage1Hash))
+	// inner Hash
+	crypt.Reset()
+	crypt.Write(stage1)
+	hash := crypt.Sum(nil)
+	// outer Hash
+	crypt.Reset()
+	crypt.Write(salt)
+	crypt.Write(hash)
+	scramble := crypt.Sum(nil)
+
+	// token = scrambleHash XOR stage1Hash
+	for i := range scramble {
+		scramble[i] ^= stage1[i]
+	}
+	return scramble
+}
+
+// ScrambleCachingSha2Password computes the hash of the password using SHA256 as required by
+// caching_sha2_password plugin for "fast" authentication
+func ScrambleCachingSha2Password(salt []byte, password []byte) []byte {
+	if len(password) == 0 {
+		return nil
+	}
+
+	// stage1Hash = SHA256(password)
+	crypt := sha256.New()
+	crypt.Write(password)
+	stage1 := crypt.Sum(nil)
+
+	// scrambleHash = SHA256(SHA256(stage1Hash) + salt)
+	crypt.Reset()
+	crypt.Write(stage1)
+	innerHash := crypt.Sum(nil)
+
+	crypt.Reset()
+	crypt.Write(innerHash)
+	crypt.Write(salt)
+	scramble := crypt.Sum(nil)
+
+	// token = stage1Hash XOR scrambleHash
+	for i := range stage1 {
+		stage1[i] ^= scramble[i]
+	}
+
+	return stage1
+}
+
+// EncryptPasswordWithPublicKey obfuscates the password and encrypts it with server's public key as required by
+// caching_sha2_password plugin for "full" authentication
+func EncryptPasswordWithPublicKey(salt []byte, password []byte, pub *rsa.PublicKey) ([]byte, error) {
+	if len(password) == 0 {
+		return nil, nil
+	}
+
+	buffer := make([]byte, len(password)+1)
+	copy(buffer, password)
+	for i := range buffer {
+		buffer[i] ^= salt[i%len(salt)]
+	}
+
+	sha1Hash := sha1.New()
+	enc, err := rsa.EncryptOAEP(sha1Hash, rand.Reader, pub, buffer, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return enc, nil
 }

--- a/go/mysql/client.go
+++ b/go/mysql/client.go
@@ -720,7 +720,7 @@ func (c *Conn) writeHandshakeResponse41(capabilities uint32, scrambledPassword [
 		c.schemaName = params.DbName
 	}
 
-	// Assume native client during response
+	// Auth plugin name
 	pos = writeNullString(data, pos, c.authPluginName)
 
 	// Sanity-check the length.
@@ -770,6 +770,10 @@ func (c *Conn) requestPublicKey() (rsaKey *rsa.PublicKey, err error) {
 	}
 
 	block, _ := pem.Decode(response[1:])
+	if block == nil {
+		return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "failed to decode response from server: %v", err)
+	}
+
 	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
 	if err != nil {
 		return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "failed to parse public key from server: %v", err)

--- a/go/mysql/client_test.go
+++ b/go/mysql/client_test.go
@@ -18,14 +18,22 @@ package mysql
 
 import (
 	"context"
+	"crypto/tls"
+	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
+	"path"
 	"runtime"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/dolthub/vitess/go/vt/tlstest"
+	"github.com/dolthub/vitess/go/vt/vttls"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // assertSQLError makes sure we get the right error.
@@ -135,4 +143,370 @@ func TestConnectTimeout(t *testing.T) {
 	} else {
 		assertSQLError(t, err, CRConnectionError, SSUnknownSQLState, "connection refused", "")
 	}
+}
+
+// TestTLSClientDisabled creates a Server with TLS support, then connects
+// with a client with TLS disabled.
+func TestTLSClientDisabled(t *testing.T) {
+	th := &testHandler{}
+
+	authServer := NewAuthServerStatic("", "", 0)
+	authServer.entries["user1"] = []*AuthServerStaticEntry{{
+		Password: "password1",
+	}}
+	defer authServer.close()
+
+	// Create the listener, so we can get its host.
+	// Below, we are enabling --ssl-verify-server-cert, which adds
+	// a check that the common name of the certificate matches the
+	// server host name we connect to.
+	l, err := NewListener("tcp", "127.0.0.1:", authServer, th, 0, 0)
+	require.NoError(t, err)
+	defer l.Close()
+
+	host := l.Addr().(*net.TCPAddr).IP.String()
+	port := l.Addr().(*net.TCPAddr).Port
+
+	// Create the certs.
+	root := t.TempDir()
+	tlstest.CreateCA(root)
+	tlstest.CreateSignedCert(root, tlstest.CA, "01", "server", host)
+	tlstest.CreateSignedCert(root, tlstest.CA, "02", "client", "Client Cert")
+
+	// Create the server with TLS config.
+	serverConfig, err := vttls.ServerConfig(
+		path.Join(root, "server-cert.pem"),
+		path.Join(root, "server-key.pem"),
+		"",
+		"",
+		"",
+		tls.VersionTLS12)
+	require.NoError(t, err)
+	l.TLSConfig = serverConfig
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func(l *Listener) {
+		wg.Done()
+		l.Accept()
+	}(l)
+	// This is ensure the listener is called
+	wg.Wait()
+	// Sleep so that the Accept function is called as well.'
+	time.Sleep(3 * time.Second)
+
+	// Setup the right parameters.
+	params := &ConnParams{
+		Host:    host,
+		Port:    port,
+		Uname:   "user1",
+		Pass:    "password1",
+		SslMode: vttls.Disabled,
+	}
+
+	conn, err := Connect(context.Background(), params)
+	require.NoError(t, err)
+
+	// make sure this went through SSL
+	results, err := conn.ExecuteFetch("ssl echo", 1000, true)
+	require.NoError(t, err)
+	assert.Equal(t, "OFF", results.Rows[0][0].ToString())
+
+	if conn != nil {
+		conn.Close()
+	}
+}
+
+// TestTLSClientDisabled creates a Server with TLS support, then connects
+// with a client with TLS preferred.
+func TestTLSClientPreferredDefault(t *testing.T) {
+	th := &testHandler{}
+
+	authServer := NewAuthServerStatic("", "", 0)
+	authServer.entries["user1"] = []*AuthServerStaticEntry{{
+		Password: "password1",
+	}}
+	defer authServer.close()
+
+	// Create the listener, so we can get its host.
+	// Below, we are enabling --ssl-verify-server-cert, which adds
+	// a check that the common name of the certificate matches the
+	// server host name we connect to.
+	l, err := NewListener("tcp", "127.0.0.1:", authServer, th, 0, 0)
+	require.NoError(t, err)
+	defer l.Close()
+
+	host := l.Addr().(*net.TCPAddr).IP.String()
+	port := l.Addr().(*net.TCPAddr).Port
+
+	// Create the certs.
+	root := t.TempDir()
+	tlstest.CreateCA(root)
+	tlstest.CreateSignedCert(root, tlstest.CA, "01", "server", "server.example.com")
+	tlstest.CreateSignedCert(root, tlstest.CA, "02", "client", "Client Cert")
+
+	// Create the server with TLS config.
+	serverConfig, err := vttls.ServerConfig(
+		path.Join(root, "server-cert.pem"),
+		path.Join(root, "server-key.pem"),
+		"",
+		"",
+		"",
+		tls.VersionTLS12)
+	require.NoError(t, err)
+	l.TLSConfig = serverConfig
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func(l *Listener) {
+		wg.Done()
+		l.Accept()
+	}(l)
+	// This is ensure the listener is called
+	wg.Wait()
+	// Sleep so that the Accept function is called as well.'
+	time.Sleep(3 * time.Second)
+
+	// Setup the right parameters.
+	params := &ConnParams{
+		Host:       host,
+		Port:       port,
+		Uname:      "user1",
+		Pass:       "password1",
+		SslMode:    vttls.Preferred,
+		ServerName: "server.example.com",
+	}
+
+	conn, err := Connect(context.Background(), params)
+	require.NoError(t, err)
+
+	// make sure this went through SSL
+	results, err := conn.ExecuteFetch("ssl echo", 1000, true)
+	require.NoError(t, err)
+	assert.Equal(t, "ON", results.Rows[0][0].ToString())
+
+	if conn != nil {
+		conn.Close()
+	}
+}
+
+// TestTLSClientRequired creates a Server with no TLS support, then connects
+// with a client with TLS required.
+func TestTLSClientRequired(t *testing.T) {
+	th := &testHandler{}
+
+	authServer := NewAuthServerStatic("", "", 0)
+	authServer.entries["user1"] = []*AuthServerStaticEntry{{
+		Password: "password1",
+	}}
+	defer authServer.close()
+
+	// Create the listener, so we can get its host.
+	// Below, we are enabling --ssl-verify-server-cert, which adds
+	// a check that the common name of the certificate matches the
+	// server host name we connect to.
+	l, err := NewListener("tcp", "127.0.0.1:", authServer, th, 0, 0)
+	require.NoError(t, err)
+	defer l.Close()
+
+	host := l.Addr().(*net.TCPAddr).IP.String()
+	port := l.Addr().(*net.TCPAddr).Port
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func(l *Listener) {
+		wg.Done()
+		l.Accept()
+	}(l)
+	// This is ensure the listener is called
+	wg.Wait()
+	// Sleep so that the Accept function is called as well.'
+	time.Sleep(3 * time.Second)
+
+	// Setup the right parameters.
+	params := &ConnParams{
+		Host:    host,
+		Port:    port,
+		Uname:   "user1",
+		Pass:    "password1",
+		SslMode: vttls.Required,
+	}
+
+	_, err = Connect(context.Background(), params)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "server doesn't support SSL but client asked for it")
+}
+
+// TestTLSClientVerifyCA creates a Server with TLS support, then connects
+// with a client with TLS enabled on a wrong hostname but with verify CA on.
+func TestTLSClientVerifyCA(t *testing.T) {
+	th := &testHandler{}
+
+	authServer := NewAuthServerStatic("", "", 0)
+	authServer.entries["user1"] = []*AuthServerStaticEntry{{
+		Password: "password1",
+	}}
+	defer authServer.close()
+
+	// Create the listener, so we can get its host.
+	// Below, we are enabling --ssl-verify-server-cert, which adds
+	// a check that the common name of the certificate matches the
+	// server host name we connect to.
+	l, err := NewListener("tcp", "127.0.0.1:", authServer, th, 0, 0)
+	require.NoError(t, err)
+	defer l.Close()
+
+	host := l.Addr().(*net.TCPAddr).IP.String()
+	port := l.Addr().(*net.TCPAddr).Port
+
+	// Create the certs.
+	root := t.TempDir()
+	tlstest.CreateCA(root)
+	tlstest.CreateSignedCert(root, tlstest.CA, "01", "server", "server.example.com")
+	tlstest.CreateSignedCert(root, tlstest.CA, "02", "client", "Client Cert")
+
+	// Create the server with TLS config.
+	serverConfig, err := vttls.ServerConfig(
+		path.Join(root, "server-cert.pem"),
+		path.Join(root, "server-key.pem"),
+		"",
+		"",
+		"",
+		tls.VersionTLS12)
+	require.NoError(t, err)
+	l.TLSConfig = serverConfig
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func(l *Listener) {
+		wg.Done()
+		l.Accept()
+	}(l)
+	// This is ensure the listener is called
+	wg.Wait()
+	// Sleep so that the Accept function is called as well.'
+	time.Sleep(3 * time.Second)
+
+	// Setup the right parameters.
+	params := &ConnParams{
+		Host:  host,
+		Port:  port,
+		Uname: "user1",
+		Pass:  "password1",
+		// SSL flags.
+		SslMode:    vttls.VerifyCA,
+		ServerName: "server.example.com",
+	}
+
+	_, err = Connect(context.Background(), params)
+	require.Error(t, err)
+
+	fmt.Printf("Error: %s", err)
+
+	assert.Contains(t, err.Error(), "certificate is not trusted")
+
+	// Now setup proper CA that is valid to verify
+	params.SslCa = path.Join(root, "ca-cert.pem")
+	conn, err := Connect(context.Background(), params)
+	require.NoError(t, err)
+
+	// make sure this went through SSL
+	results, err := conn.ExecuteFetch("ssl echo", 1000, true)
+	require.NoError(t, err)
+	assert.Equal(t, "ON", results.Rows[0][0].ToString())
+
+	if conn != nil {
+		conn.Close()
+	}
+}
+
+// TestTLSClientVerifyIdentity creates a Server with TLS support, then connects
+// with a client with TLS enabled on a wrong hostname but with verify CA on.
+func TestTLSClientVerifyIdentity(t *testing.T) {
+	th := &testHandler{}
+
+	authServer := NewAuthServerStatic("", "", 0)
+	authServer.entries["user1"] = []*AuthServerStaticEntry{{
+		Password: "password1",
+	}}
+	defer authServer.close()
+
+	// Create the listener, so we can get its host.
+	// Below, we are enabling --ssl-verify-server-cert, which adds
+	// a check that the common name of the certificate matches the
+	// server host name we connect to.
+	l, err := NewListener("tcp", "127.0.0.1:", authServer, th, 0, 0)
+	require.NoError(t, err)
+	defer l.Close()
+
+	host := l.Addr().(*net.TCPAddr).IP.String()
+	port := l.Addr().(*net.TCPAddr).Port
+
+	// Create the certs.
+	root := t.TempDir()
+	tlstest.CreateCA(root)
+	tlstest.CreateSignedCert(root, tlstest.CA, "01", "server", "server.example.com")
+	tlstest.CreateSignedCert(root, tlstest.CA, "02", "client", "Client Cert")
+
+	// Create the server with TLS config.
+	serverConfig, err := vttls.ServerConfig(
+		path.Join(root, "server-cert.pem"),
+		path.Join(root, "server-key.pem"),
+		"",
+		"",
+		"",
+		tls.VersionTLS12)
+	require.NoError(t, err)
+	l.TLSConfig = serverConfig
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func(l *Listener) {
+		wg.Done()
+		l.Accept()
+	}(l)
+	// This is ensure the listener is called
+	wg.Wait()
+	// Sleep so that the Accept function is called as well.'
+	time.Sleep(3 * time.Second)
+
+	// Setup the right parameters.
+	params := &ConnParams{
+		Host:  host,
+		Port:  port,
+		Uname: "user1",
+		Pass:  "password1",
+		// SSL flags.
+		SslMode:    vttls.VerifyIdentity,
+		ServerName: "server.example.com",
+	}
+
+	_, err = Connect(context.Background(), params)
+	require.Error(t, err)
+
+	fmt.Printf("Error: %s", err)
+
+	assert.Contains(t, err.Error(), "certificate is not trusted")
+
+	// Now setup proper CA that is valid to verify
+	params.SslCa = path.Join(root, "ca-cert.pem")
+	conn, err := Connect(context.Background(), params)
+	require.NoError(t, err)
+
+	// make sure this went through SSL
+	results, err := conn.ExecuteFetch("ssl echo", 1000, true)
+	require.NoError(t, err)
+	assert.Equal(t, "ON", results.Rows[0][0].ToString())
+
+	if conn != nil {
+		conn.Close()
+	}
+
+	// Now revoke the server certificate and make sure we can't connect
+	tlstest.RevokeCertAndRegenerateCRL(root, tlstest.CA, "server")
+
+	params.SslCrl = path.Join(root, "ca-crl.pem")
+	_, err = Connect(context.Background(), params)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Certificate revoked: CommonName=server.example.com")
 }

--- a/go/mysql/client_test.go
+++ b/go/mysql/client_test.go
@@ -403,7 +403,7 @@ func TestTLSClientVerifyCA(t *testing.T) {
 
 	fmt.Printf("Error: %s", err)
 
-	assert.Contains(t, err.Error(), "certificate is not trusted")
+	assert.Contains(t, err.Error(), "x509: certificate")
 
 	// Now setup proper CA that is valid to verify
 	params.SslCa = path.Join(root, "ca-cert.pem")
@@ -486,7 +486,7 @@ func TestTLSClientVerifyIdentity(t *testing.T) {
 
 	fmt.Printf("Error: %s", err)
 
-	assert.Contains(t, err.Error(), "certificate is not trusted")
+	assert.Contains(t, err.Error(), "x509: certificate")
 
 	// Now setup proper CA that is valid to verify
 	params.SslCa = path.Join(root, "ca-cert.pem")

--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -72,6 +72,13 @@ type Getter interface {
 // Use Connect on the client side to create a connection.
 // Use NewListener to create a server side and listen for connections.
 type Conn struct {
+	// salt is sent by the server during initial handshake to be used for authentication
+	salt []byte
+
+	// authPluginName is the name of server's authentication plugin.
+	// It is set during the initial handshake.
+	authPluginName string
+
 	// conn is the underlying network connection.
 	// Calling Close() on the Conn will close this connection.
 	// If there are any ongoing reads or writes, they may get interrupted.
@@ -1241,7 +1248,7 @@ func (c *Conn) handleNextCommand(handler Handler) error {
 // formatID returns a quoted identifier from the one given. Adapted from ast.go
 func formatID(original string) string {
 	var sb strings.Builder
-	
+
 	sb.WriteByte('`')
 	for _, c := range original {
 		sb.WriteRune(c)
@@ -1250,7 +1257,7 @@ func formatID(original string) string {
 		}
 	}
 	sb.WriteByte('`')
-	
+
 	return sb.String()
 }
 

--- a/go/mysql/constants.go
+++ b/go/mysql/constants.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package mysql
 
+import (
+	"strings"
+)
+
 const (
 	// MaxPacketSize is the maximum payload length of a packet
 	// the server supports.
@@ -33,6 +37,9 @@ const (
 
 	// MysqlClearPassword transmits the password in the clear.
 	MysqlClearPassword = "mysql_clear_password"
+
+	// CachingSha2Password uses a salt and transmits a SHA256 hash on the wire.
+	CachingSha2Password = "caching_sha2_password"
 
 	// MysqlDialog uses the dialog plugin on the client side.
 	// It transmits data in the clear.
@@ -128,10 +135,37 @@ const (
 	// Can set SERVER_SESSION_STATE_CHANGED in the Status Flags
 	// and send session-state change data after a OK packet.
 	// Not yet supported.
+	CapabilityClientSessionTrack = 1 << 23
 
 	// CapabilityClientDeprecateEOF is CLIENT_DEPRECATE_EOF
 	// Expects an OK (instead of EOF) after the resultset rows of a Text Resultset.
 	CapabilityClientDeprecateEOF = 1 << 24
+)
+
+// Status flags. They are returned by the server in a few cases.
+// Originally found in include/mysql/mysql_com.h
+// See http://dev.mysql.com/doc/internals/en/status-flags.html
+const (
+	// ServerInTransaction is SERVER_STATUS_IN_TRANS (a transaction is active)
+	ServerInTransaction = 0x0001
+
+	// ServerStatusAutocommit is SERVER_STATUS_AUTOCOMMIT.
+	ServerStatusAutocommit = 0x0002
+
+	// ServerMoreResultsExists is SERVER_MORE_RESULTS_EXISTS
+	ServerMoreResultsExists = 0x0008
+)
+
+// State Change Information
+const (
+	// one or more system variables changed.
+	SessionTrackSystemVariables uint8 = 0x00
+	// schema changed.
+	SessionTrackSchema uint8 = 0x01
+	// "track state change" changed.
+	SessionTrackStateChange uint8 = 0x02
+	// "track GTIDs" changed.
+	SessionTrackGtids uint8 = 0x03
 )
 
 // Packet types.
@@ -190,9 +224,6 @@ const (
 
 	LocalInfilePacket = 0xFB
 
-	// AuthSwitchRequestPacket is used to switch auth method.
-	AuthSwitchRequestPacket = 0xfe
-
 	// ErrPacket is the header of the error packet.
 	ErrPacket = 0xff
 
@@ -200,9 +231,24 @@ const (
 	NullValue = 0xfb
 )
 
+// Auth packet types
+const (
+	// AuthMoreDataPacket is sent when server requires more data to authenticate
+	AuthMoreDataPacket = 0x01
+
+	// CachingSha2FastAuth is sent before OKPacket when server authenticates using cache
+	CachingSha2FastAuth = 0x03
+
+	// CachingSha2FullAuth is sent when server requests un-scrambled password to authenticate
+	CachingSha2FullAuth = 0x04
+
+	// AuthSwitchRequestPacket is used to switch auth method.
+	AuthSwitchRequestPacket = 0xfe
+)
+
 // Error codes for client-side errors.
 // Originally found in include/mysql/errmsg.h and
-// https://dev.mysql.com/doc/refman/5.7/en/error-messages-client.html
+// https://dev.mysql.com/doc/mysql-errors/en/client-error-reference.html
 const (
 	// CRUnknownError is CR_UNKNOWN_ERROR
 	CRUnknownError = 2000
@@ -214,6 +260,10 @@ const (
 	// CRConnHostError is CR_CONN_HOST_ERROR
 	// This is returned if a connection via a TCP socket fails.
 	CRConnHostError = 2003
+
+	// CRUnknownHost is CR_UNKNOWN_HOST
+	// This is returned if the host name cannot be resolved.
+	CRUnknownHost = 2005
 
 	// CRServerGone is CR_SERVER_GONE_ERROR.
 	// This is returned if the client tries to send a command but it fails.
@@ -231,6 +281,7 @@ const (
 	// - the client cannot write an initial auth packet.
 	// - the client cannot read an initial auth packet.
 	// - the client cannot read a response from the server.
+	//     This happens when a running query is killed.
 	CRServerLost = 2013
 
 	// CRCommandsOutOfSync is CR_COMMANDS_OUT_OF_SYNC
@@ -260,12 +311,15 @@ const (
 
 // Error codes for server-side errors.
 // Originally found in include/mysql/mysqld_error.h and
-// https://dev.mysql.com/doc/refman/5.7/en/error-messages-server.html
+// https://dev.mysql.com/doc/mysql-errors/en/server-error-reference.html
 // The below are in sorted order by value, grouped by vterror code they should be bucketed into.
 // See above reference for more information on each code.
 const (
 	// unknown
 	ERUnknownError = 1105
+
+	// internal
+	ERInternalError = 1815
 
 	// unimplemented
 	ERNotSupportedYet = 1235
@@ -330,21 +384,28 @@ const (
 	ERRowIsReferenced               = 1217
 	ERCantUpdateWithReadLock        = 1223
 	ERNoDefault                     = 1230
+	ERMasterFatalReadingBinlog      = 1236
 	EROperandColumns                = 1241
 	ERSubqueryNo1Row                = 1242
+	ERWarnDataOutOfRange            = 1264
 	ERNonUpdateableTable            = 1288
 	ERFeatureDisabled               = 1289
 	EROptionPreventsStatement       = 1290
 	ERDuplicatedValueInType         = 1291
+	ERSPDoesNotExist                = 1305
+	ERNoDefaultForField             = 1364
+	ErSPNotVarArg                   = 1414
 	ERRowIsReferenced2              = 1451
 	ErNoReferencedRow2              = 1452
+	ERDupIndex                      = 1831
+	ERInnodbReadOnly                = 1874
 
 	// already exists
+	ERDbCreateExists = 1007
 	ERTableExists    = 1050
 	ERDupEntry       = 1062
 	ERFileExists     = 1086
 	ERUDFExists      = 1125
-	ERDbCreateExists = 1007
 
 	// aborted
 	ERGotSignal          = 1078
@@ -413,6 +474,7 @@ const (
 	ERBlobKeyWithoutLength         = 1170
 	ERPrimaryCantHaveNull          = 1171
 	ERTooManyRows                  = 1172
+	ERLockOrActiveTransaction      = 1192
 	ERUnknownSystemVariable        = 1193
 	ERSetConstantsOnly             = 1204
 	ERWrongArguments               = 1210
@@ -429,7 +491,11 @@ const (
 	ERWrongFKDef                   = 1239
 	ERKeyRefDoNotMatchTableRef     = 1240
 	ERCyclicReference              = 1245
+	ERIllegalReference             = 1247
+	ERDerivedMustHaveAlias         = 1248
+	ERTableNameNotAllowedHere      = 1250
 	ERCollationCharsetMismatch     = 1253
+	ERWarnDataTruncated            = 1265
 	ERCantAggregate2Collations     = 1267
 	ERCantAggregate3Collations     = 1270
 	ERCantAggregateNCollations     = 1271
@@ -443,13 +509,33 @@ const (
 	ERInvalidOnUpdate              = 1294
 	ERUnknownTimeZone              = 1298
 	ERInvalidCharacterString       = 1300
-	ERIllegalReference             = 1247
-	ERDerivedMustHaveAlias         = 1248
-	ERTableNameNotAllowedHere      = 1250
 	ERQueryInterrupted             = 1317
 	ERTruncatedWrongValueForField  = 1366
+	ERIllegalValueForType          = 1367
 	ERDataTooLong                  = 1406
+	ErrWrongValueForType           = 1411
+	ERForbidSchemaChange           = 1450
+	ERWrongValue                   = 1525
 	ERDataOutOfRange               = 1690
+	ERInvalidJSONText              = 3140
+	ERInvalidJSONTextInParams      = 3141
+	ERInvalidJSONBinaryData        = 3142
+	ERInvalidJSONCharset           = 3144
+	ERInvalidCastToJSON            = 3147
+	ERJSONValueTooBig              = 3150
+	ERJSONDocumentTooDeep          = 3157
+
+	// max execution time exceeded
+	ERQueryTimeout = 3024
+
+	ErrCantCreateGeometryObject      = 1416
+	ErrGISDataWrongEndianess         = 3055
+	ErrNotImplementedForCartesianSRS = 3704
+	ErrNotImplementedForProjectedSRS = 3705
+	ErrNonPositiveRadius             = 3706
+
+	// server not available
+	ERServerIsntAvailable = 3168
 )
 
 // Sql states for errors.
@@ -461,11 +547,17 @@ const (
 	// in client.c. So using that one.
 	SSUnknownSQLState = "HY000"
 
+	// SSNetError is network related error
+	SSNetError = "08S01"
+
 	// SSUnknownComError is ER_UNKNOWN_COM_ERROR
 	SSUnknownComError = "08S01"
 
-	// SSHandshakeError is ER_HANDSHAKE_ERROR
-	SSHandshakeError = "08S01"
+	// SSWrongNumberOfColumns is related to columns error
+	SSWrongNumberOfColumns = "21000"
+
+	// SSWrongValueCountOnRow is related to columns count mismatch error
+	SSWrongValueCountOnRow = "21S01"
 
 	// SSServerShutdown is ER_SERVER_SHUTDOWN
 	SSServerShutdown = "08S01"
@@ -476,14 +568,8 @@ const (
 	// SSDataOutOfRange is ER_DATA_OUT_OF_RANGE
 	SSDataOutOfRange = "22003"
 
-	// SSBadNullError is ER_BAD_NULL_ERROR
-	SSBadNullError = "23000"
-
-	// SSBadFieldError is ER_BAD_FIELD_ERROR
-	SSBadFieldError = "42S22"
-
-	// SSDupKey is ER_DUP_KEY
-	SSDupKey = "23000"
+	// SSConstraintViolation is constraint violation
+	SSConstraintViolation = "23000"
 
 	// SSCantDoThisDuringAnTransaction is
 	// ER_CANT_DO_THIS_DURING_AN_TRANSACTION
@@ -492,22 +578,26 @@ const (
 	// SSAccessDeniedError is ER_ACCESS_DENIED_ERROR
 	SSAccessDeniedError = "28000"
 
+	// SSNoDB is ER_NO_DB_ERROR
+	SSNoDB = "3D000"
+
 	// SSLockDeadlock is ER_LOCK_DEADLOCK
 	SSLockDeadlock = "40001"
-)
 
-// Status flags. They are returned by the server in a few cases.
-// Originally found in include/mysql/mysql_com.h
-// See http://dev.mysql.com/doc/internals/en/status-flags.html
-const (
-	// ServerInTransaction is SERVER_STATUS_IN_TRANS (a transaction is active)
-	ServerInTransaction = 0x0001
+	// SSClientError is the state on client errors
+	SSClientError = "42000"
 
-	// ServerStatusAutocommit is SERVER_STATUS_AUTOCOMMIT.
-	ServerStatusAutocommit = 0x0002
+	// SSDupFieldName is ER_DUP_FIELD_NAME
+	SSDupFieldName = "42S21"
 
-	// ServerMoreResultsExists is SERVER_MORE_RESULTS_EXISTS
-	ServerMoreResultsExists = 0x0008
+	// SSBadFieldError is ER_BAD_FIELD_ERROR
+	SSBadFieldError = "42S22"
+
+	// SSUnknownTable is ER_UNKNOWN_TABLE
+	SSUnknownTable = "42S02"
+
+	// SSQueryInterrupted is ER_QUERY_INTERRUPTED;
+	SSQueryInterrupted = "70100"
 )
 
 // A few interesting character set values.
@@ -567,18 +657,30 @@ var CharacterSetMap = map[string]uint8{
 
 // IsNum returns true if a MySQL type is a numeric value.
 // It is the same as IS_NUM defined in mysql.h.
-//
-// FIXME(alainjobart) This needs to use the constants in
-// replication/constants.go, so we are using numerical values here.
 func IsNum(typ uint8) bool {
-	return ((typ <= 9 /* MYSQL_TYPE_INT24 */ && typ != 7 /* MYSQL_TYPE_TIMESTAMP */) || typ == 13 /* MYSQL_TYPE_YEAR */ || typ == 246 /* MYSQL_TYPE_NEWDECIMAL */)
+	return (typ <= TypeInt24 && typ != TypeTimestamp) ||
+		typ == TypeYear ||
+		typ == TypeNewDecimal
 }
 
 // IsConnErr returns true if the error is a connection error.
 func IsConnErr(err error) bool {
+	if IsTooManyConnectionsErr(err) {
+		return false
+	}
 	if sqlErr, ok := err.(*SQLError); ok {
 		num := sqlErr.Number()
 		return (num >= CRUnknownError && num <= CRNamedPipeStateError) || num == ERQueryInterrupted
+	}
+	return false
+}
+
+// IsTooManyConnectionsErr returns true if the error is due to too many connections.
+func IsTooManyConnectionsErr(err error) bool {
+	if sqlErr, ok := err.(*SQLError); ok {
+		if sqlErr.Number() == CRServerHandshakeErr && strings.Contains(sqlErr.Message, "Too many connections") {
+			return true
+		}
 	}
 	return false
 }

--- a/go/mysql/constants.go
+++ b/go/mysql/constants.go
@@ -571,6 +571,9 @@ const (
 	// SSConstraintViolation is constraint violation
 	SSConstraintViolation = "23000"
 
+	// SSDupKey is ER_DUP_KEY
+	SSDupKey = "23000"
+
 	// SSCantDoThisDuringAnTransaction is
 	// ER_CANT_DO_THIS_DURING_AN_TRANSACTION
 	SSCantDoThisDuringAnTransaction = "25000"


### PR DESCRIPTION
The MySQL client API in our fork of vitess is limited to the `mysql_native_password` auth plugin, but the default auth plugin as of MySQL 8.0 is `caching_sha2_password`. This means that to use Dolt binlog replication, customers either have to change the default auth plugin in MySQL or they have to create a user that is identified with the older `mysql_native_password` auth plugin. This additional configuration step adds friction for customers wanting to try out Dolt binlog replication.

This PR pulls in selected changes from the tip of `vitessio/vitess` to pick up client support for connecting to MySQL servers that default to `caching_sha2_password` auth plugin (and will still fall back to `mysql_native_password`). All of these changes are pulled directly from `vitessio/vitess`, without any other changes mixed in. 

I'm not aware of anywhere else in our codebase where we're using the MySQL client API from vitess. As far as I know, it's only used by the binlog implementation. That means this change shouldn't have any effect on other parts of Dolt/GMS, and I've gone ahead and run the Dolt CI tests against this change as a sanity check:
- https://github.com/dolthub/dolt/pull/5339

I've pulled over additional tests from the tip of vitess for this logic. I've also tested locally and confirmed that my binlog replication integ tests all pass with this change, and no longer require overriding the default auth plugin for the MySQL server. I've also started on some additional binlog replication integ tests to make sure we cover password/no-password and ssl/no-ssl. 