### PR TITLE
Exposing SQL Option and SQL Mode flags for Query events

### DIFF
--- a/go/mysql/binlog_event.go
+++ b/go/mysql/binlog_event.go
@@ -163,6 +163,8 @@ type Query struct {
 	Database string
 	Charset  *binlogdatapb.Charset
 	SQL      string
+	Options  uint32
+	SqlMode  uint64
 }
 
 // String pretty-prints a Query.

--- a/go/mysql/binlog_event_common.go
+++ b/go/mysql/binlog_event_common.go
@@ -30,24 +30,23 @@ import (
 // into flavor-specific event types to pull in common parsing code.
 //
 // The default v4 header format is:
-//
-//	               offset : size
-//	+============================+
-//	| timestamp         0 : 4    |
-//	+----------------------------+
-//	| type_code         4 : 1    |
-//	+----------------------------+
-//	| server_id         5 : 4    |
-//	+----------------------------+
-//	| event_length      9 : 4    |
-//	+----------------------------+
-//	| next_position    13 : 4    |
-//	+----------------------------+
-//	| flags            17 : 2    |
-//	+----------------------------+
-//	| extra_headers    19 : x-19 |
-//	+============================+
-//	http://dev.mysql.com/doc/internals/en/event-header-fields.html
+//                  offset : size
+//   +============================+
+//   | timestamp         0 : 4    |
+//   +----------------------------+
+//   | type_code         4 : 1    |
+//   +----------------------------+
+//   | server_id         5 : 4    |
+//   +----------------------------+
+//   | event_length      9 : 4    |
+//   +----------------------------+
+//   | next_position    13 : 4    |
+//   +----------------------------+
+//   | flags            17 : 2    |
+//   +----------------------------+
+//   | extra_headers    19 : x-19 |
+//   +============================+
+//   http://dev.mysql.com/doc/internals/en/event-header-fields.html
 type binlogEvent []byte
 
 // IsValid implements BinlogEvent.IsValid().
@@ -171,16 +170,15 @@ func (ev binlogEvent) IsPseudo() bool {
 // Format implements BinlogEvent.Format().
 //
 // Expected format (L = total length of event data):
-//
-//	# bytes   field
-//	2         format version
-//	50        server version string, 0-padded but not necessarily 0-terminated
-//	4         timestamp (same as timestamp header field)
-//	1         header length
-//	p         (one byte per packet type) event type header lengths
-//	          Rest was inferred from reading source code:
-//	1         checksum algorithm
-//	4         checksum
+//   # bytes   field
+//   2         format version
+//   50        server version string, 0-padded but not necessarily 0-terminated
+//   4         timestamp (same as timestamp header field)
+//   1         header length
+//   p         (one byte per packet type) event type header lengths
+//             Rest was inferred from reading source code:
+//   1         checksum algorithm
+//   4         checksum
 func (ev binlogEvent) Format() (f BinlogFormat, err error) {
 	// FORMAT_DESCRIPTION_EVENT has a fixed header size of 19
 	// because we have to read it before we know the header_length.
@@ -209,16 +207,15 @@ func (ev binlogEvent) Format() (f BinlogFormat, err error) {
 // Query implements BinlogEvent.Query().
 //
 // Expected format (L = total length of event data):
-//
-//	# bytes   field
-//	4         thread_id
-//	4         execution time
-//	1         length of db_name, not including NULL terminator (X)
-//	2         error code
-//	2         length of status vars block (Y)
-//	Y         status vars block
-//	X+1       db_name + NULL terminator
-//	L-X-1-Y   SQL statement (no NULL terminator)
+//   # bytes   field
+//   4         thread_id
+//   4         execution time
+//   1         length of db_name, not including NULL terminator (X)
+//   2         error code
+//   2         length of status vars block (Y)
+//   Y         status vars block
+//   X+1       db_name + NULL terminator
+//   L-X-1-Y   SQL statement (no NULL terminator)
 func (ev binlogEvent) Query(f BinlogFormat) (query Query, err error) {
 	const varsPos = 4 + 4 + 1 + 2 + 2
 
@@ -295,10 +292,9 @@ varsLoop:
 // IntVar implements BinlogEvent.IntVar().
 //
 // Expected format (L = total length of event data):
-//
-//	# bytes   field
-//	1         variable ID
-//	8         variable value
+//   # bytes   field
+//   1         variable ID
+//   8         variable value
 func (ev binlogEvent) IntVar(f BinlogFormat) (byte, uint64, error) {
 	data := ev.Bytes()[f.HeaderLength:]
 
@@ -314,10 +310,9 @@ func (ev binlogEvent) IntVar(f BinlogFormat) (byte, uint64, error) {
 // Rand implements BinlogEvent.Rand().
 //
 // Expected format (L = total length of event data):
-//
-//	# bytes   field
-//	8         seed 1
-//	8         seed 2
+//   # bytes   field
+//   8         seed 1
+//   8         seed 2
 func (ev binlogEvent) Rand(f BinlogFormat) (seed1 uint64, seed2 uint64, err error) {
 	data := ev.Bytes()[f.HeaderLength:]
 	seed1 = binary.LittleEndian.Uint64(data[0:8])

--- a/go/mysql/binlog_event_common.go
+++ b/go/mysql/binlog_event_common.go
@@ -253,10 +253,10 @@ varsLoop:
 		// for backward compatibility.
 		switch code {
 		case QFlags2Code:
-			query.Options = binary.LittleEndian.Uint32(data[pos : pos+4])
+			query.Options = binary.LittleEndian.Uint32(vars[pos : pos+4])
 			pos += 4
 		case QSQLModeCode:
-			query.SqlMode = binary.LittleEndian.Uint64(data[pos : pos+8])
+			query.SqlMode = binary.LittleEndian.Uint64(vars[pos : pos+8])
 			pos += 8
 		case QAutoIncrement:
 			pos += 4

--- a/go/mysql/binlog_event_common_test.go
+++ b/go/mysql/binlog_event_common_test.go
@@ -253,6 +253,8 @@ eid bigint,
 id int,
 primary key(eid, id)
 ) Engine=InnoDB`,
+		Options: QFlagOptionAutoIsNull,
+		SqlMode: QSqlModeStrictTransTables,
 	}
 	got, err := input.Query(f)
 	if err != nil {

--- a/go/mysql/replication_constants.go
+++ b/go/mysql/replication_constants.go
@@ -225,3 +225,49 @@ const (
 	// QCatalogNZCode is Q_CATALOG_NZ_CODE
 	QCatalogNZCode = 6
 )
+
+// These constants describe the values in the QFlags2Code bitmask field of Query events.
+// From: https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_replication_binlog_event.html#sect_protocol_replication_event_query_03
+const (
+	QFlagOptionAutoIsNull          = 0x00004000
+	QFlagOptionNotAutocommit       = 0x00080000
+	QFlagOptionNoForeignKeyChecks  = 0x04000000
+	QFlagOptionRelaxedUniqueChecks = 0x08000000
+)
+
+// These constants describe the values in the QSQLModeCode bitmask field of Query events.
+// From: https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_replication_binlog_event.html#sect_protocol_replication_event_query_03
+const (
+	QSqlModeRealAsFloat            = 0x00000001
+	QSqlModePipesAsConcat          = 0x00000002
+	QSqlModeAnsiQuotes             = 0x00000004
+	QSqlModeIgnoreSpace            = 0x00000008
+	QSqlModeNotUsed                = 0x00000010
+	QSqlModeOnlyFullGroupBy        = 0x00000020
+	QSqlModeNoUnsignedSubtraction  = 0x00000040
+	QSqlModeNoDirInCreate          = 0x00000080
+	QSqlModePostgreSql             = 0x00000100
+	QSqlModeOracle                 = 0x00000200
+	QSqlModeMsSql                  = 0x00000400
+	QSqlModeDb2                    = 0x00000800
+	QSqlModeMaxDb                  = 0x00001000
+	QSqlModeNoKeyOptions           = 0x00002000
+	QSqlModeNoTableOptions         = 0x00004000
+	QSqlModeNoFieldOptions         = 0x00008000
+	QSqlModeMySql323               = 0x00010000
+	QSqlModeMySql40                = 0x00020000
+	QSqlModeAnsi                   = 0x00040000
+	QSqlModeNoAutoValueOnZero      = 0x00080000
+	QSqlModeNoBackslashEscapes     = 0x00100000
+	QSqlModeStrictTransTables      = 0x00200000
+	QSqlModeStrictAllTables        = 0x00400000
+	QSqlModeNoZeroInDate           = 0x00800000
+	QSqlModeNoZeroDate             = 0x01000000
+	QSqlModeInvalidDates           = 0x02000000
+	QSqlModeErrorForDivisionByZero = 0x04000000
+	QSqlModeTraditional            = 0x08000000
+	QSqlModeNoAutoCreateUser       = 0x10000000
+	QSqlModeHighNotPrecedence      = 0x20000000
+	QSqlModeNoEngineSubstitution   = 0x40000000
+	QSqlModePadCharToFullLength    = 0x80000000
+)


### PR DESCRIPTION
`Query` binlog events are sent from the primary when the replica needs to execute a SQL statement directly. This is only for DDL operations, since DML operations are handled with a structured data message that indicates exactly which rows changed. 

There's extra metadata passed in `Query` binlog messages that wasn't getting exposed by Vitess that we need to execute the statements correctly (e.g. foreign_key_checks disabled). This PR exposes the SQL Options and SQL Mode metadata so that we can access them from Dolt. 