### PR TITLE
Bug fix for round tripping parsed `cast` function calls

### DIFF
--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -5808,7 +5808,11 @@ type ConvertExpr struct {
 
 // Format formats the node.
 func (node *ConvertExpr) Format(buf *TrackedBuffer) {
-	buf.Myprintf("%s(%v, %v)", node.Name, node.Expr, node.Type)
+	if strings.ToLower(node.Name) == "cast" {
+		buf.Myprintf("%s(%v as %v)", node.Name, node.Expr, node.Type)
+	} else {
+		buf.Myprintf("%s(%v, %v)", node.Name, node.Expr, node.Type)
+	}
 }
 
 func (node *ConvertExpr) walkSubtree(visit Visit) error {

--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -3784,7 +3784,7 @@ BEGIN
 		output: "create definer = `root`@`localhost` trigger forecast_db.before_ai_suggested_task_label_delete " +
 			"before delete on forecast_db.ai_suggested_task_label for each row begin\n" +
 			"if OLD.`delete` != (1) then " +
-			"set @message_text = CONCAT('CANNOT DELETE ai_suggested_task_label IF DELETE FLAG IS NOT SET FOR: ', CAST(OLD.id, CHAR)); " +
+			"set @message_text = CONCAT('CANNOT DELETE ai_suggested_task_label IF DELETE FLAG IS NOT SET FOR: ', CAST(OLD.id as CHAR)); " +
 			"signal sqlstate value '45000' set message_text = @message_text;\n" +
 			"end if;\n" +
 			"insert into forecast_db_events.event_ai_suggested_task_label(`action`, id, created_at, updated_at, created_by, updated_by, company_id, label_id, task_id, `delete`) " +
@@ -4924,7 +4924,7 @@ func TestFunctionCalls(t *testing.T) {
 	testCases := []parseTest{
 		{
 			input:  "select CAST(1 as datetime) from dual",
-			output: "select CAST(1, datetime)",
+			output: "select CAST(1 as datetime)",
 		},
 		{
 			input:  "select LOCALTIMESTAMP from dual",
@@ -4932,11 +4932,11 @@ func TestFunctionCalls(t *testing.T) {
 		},
 		{
 			input: "SELECT CAST(foo AS DOUBLE)",
-			output: "select CAST(foo, DOUBLE)",
+			output: "select CAST(foo as DOUBLE)",
 		},
 		{
 			input: "SELECT CAST(foo AS FLOAT)",
-			output: "select CAST(foo, FLOAT)",
+			output: "select CAST(foo as FLOAT)",
 		},
 	}
 
@@ -4983,7 +4983,6 @@ func TestConvert(t *testing.T) {
 	validSQL := []parseTest{
 		{
 			input:  "select cast('abc' as date) from t",
-			output: "select cast('abc', date) from t",
 		}, {
 			input:                      "select cast('abc' as date) from t",
 			useSelectExpressionLiteral: true,


### PR DESCRIPTION
When formatting a parsed `cast` node back into a SQL string, we were using the form `CAST(<arg>, <arg>)`, but that won't roundtrip back to MySQL. It needs to be either `CONVERT(<arg>, <arg>)` or `CAST(<arg> as <arg)`. 