### PR TITLE
Preserving bind var type for sqltypes.Char params

### DIFF
--- a/go/mysql/query.go
+++ b/go/mysql/query.go
@@ -901,7 +901,13 @@ func (c *Conn) parseStmtArgs(data []byte, typ querypb.Type, pos int) (sqltypes.V
 		default:
 			return sqltypes.NULL, 0, false
 		}
-	case sqltypes.Decimal, sqltypes.Text, sqltypes.Blob, sqltypes.VarChar, sqltypes.VarBinary, sqltypes.Char,
+	case sqltypes.Char:
+		// NOTE: vitessio/vitess drops the sqltypes.Char information and returns the type as VarBinary, but
+		//       that prevents us from knowing what type information the client really sent. It seems like
+		//       preserving that type information is more correct and we may want to preserve other types, too.
+		val, pos, ok := readLenEncStringAsBytesCopy(data, pos)
+		return sqltypes.MakeTrusted(sqltypes.Char, val), pos, ok
+	case sqltypes.Decimal, sqltypes.Text, sqltypes.Blob, sqltypes.VarChar, sqltypes.VarBinary,
 		sqltypes.Bit, sqltypes.Enum, sqltypes.Set, sqltypes.Geometry, sqltypes.Binary, sqltypes.TypeJSON:
 		val, pos, ok := readLenEncStringAsBytesCopy(data, pos)
 		return sqltypes.MakeTrusted(sqltypes.VarBinary, val), pos, ok


### PR DESCRIPTION
When a caller executes a prepared statement, they send the parameters as well as parameter type information to the sql-server. Vitess populates bindvars type information that go-mysql-server uses to execute the query. Vitess is currently converting many SQL types to `VARBINARY`, including `CHAR`, which makes it look like binary data was sent and not a char string, like the caller indicated. 

This change stops converting `sqltypes.Char` bind var type info into `VARBINARY`, which enables go-mysql-server to see that a char string was passed. Without this type information, go-mysql-server doesn't seem able to differentiate between legitimate binary data sent by the client versus a character string. Since these types need to be handled differently, and we can't assume that all `VARBINARY` types can be converted into strings, it seems like we need to respect the SQL type the caller indicated for the bind var and pass that up to integrators. 

It seems like this change could be helpful for other SQL types, too, but I wanted to start with just `sqltypes.Char` to see if this approach causes any other issues. 

Fixes: https://github.com/dolthub/go-mysql-server/issues/1855

Related go-mysql-server PR: https://github.com/dolthub/go-mysql-server/pull/1919
Related Dolt PR: https://github.com/dolthub/dolt/pull/6441