### PR TITLE
Update the default server version to `8.0.33`

### DIFF
--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -38,7 +38,7 @@ import (
 const (
 	// DefaultServerVersion is the default server version we're sending to the client.
 	// Can be changed.
-	DefaultServerVersion = "5.7.9-Vitess"
+	DefaultServerVersion = "8.0.33"
 
 	// timing metric keys
 	connectTimingKey  = "Connect"


### PR DESCRIPTION
The connection handshake was advertising a server version of `5.7.9-Vitess` and some clients were using that info and trying and speak MySQL-5.7 to Dolt ([example issue](https://github.com/dolthub/dolt/issues/6797))

This change updates the default advertised server version to `8.0.33-Dolt`. 

Dolt CI tests are running at: https://github.com/dolthub/dolt/pull/6798