### PR TITLE
Include the With clause in walked subtrees for Select statements

### DIFF
--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -613,6 +613,7 @@ func (node *Select) walkSubtree(visit Visit) error {
 	}
 	return Walk(
 		visit,
+		node.With,
 		node.Comments,
 		node.SelectExprs,
 		node.From,


### PR DESCRIPTION
We weren't walking the `With` clause for select statements, which caused us to not find any bind vars in use there. 

Related to: https://github.com/dolthub/dolt/issues/6852