### PR TITLE
Logging improvements

### DIFF
--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -1088,6 +1088,7 @@ func (c *Conn) handleNextCommand(handler Handler) error {
 
 		parserOptions, err := handler.ParserOptionsForConnection(c)
 		if err != nil {
+			log.Errorf("unable to determine parser options for current connection: %s", err.Error())
 			return err
 		}
 
@@ -1139,8 +1140,9 @@ func (c *Conn) handleNextCommand(handler Handler) error {
 
 		c.PrepareData[c.StatementID] = prepare
 
-		fld, err := handler.ComPrepare(c, query)
+		fld, err := handler.ComPrepare(c, query, prepare)
 		if err != nil {
+			log.Errorf("unable to prepare query: %s", err.Error())
 			if werr := c.writeErrorPacketFromError(err); werr != nil {
 				// If we can't even write the error, we're done.
 				log.Error("Error writing query error to client %v: %v", c.ConnectionID, werr)

--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -115,7 +115,7 @@ type Handler interface {
 
 	// ComPrepare is called when a connection receives a prepared
 	// statement query.
-	ComPrepare(c *Conn, query string) ([]*querypb.Field, error)
+	ComPrepare(c *Conn, query string, prepare *PrepareData) ([]*querypb.Field, error)
 
 	// ComStmtExecute is called when a connection receives a statement
 	// execute query.

--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -225,7 +225,7 @@ func (th *testHandler) ComParsedQuery(c *Conn, query string, parsed sqlparser.St
 	return th.ComQuery(c, query, callback)
 }
 
-func (th *testHandler) ComPrepare(c *Conn, query string) ([]*querypb.Field, error) {
+func (th *testHandler) ComPrepare(c *Conn, query string, prepare *PrepareData) ([]*querypb.Field, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
Logging a couple more error handling spots. Changing the `Handler` interface to pass `mysql.PrepareData` into the `ComPrepare` function so that GMS can log the params count at a debug level. 

Related GMS PR: https://github.com/dolthub/go-mysql-server/pull/2098