### PR TITLE
Add additional types to sqlparser.SQLType()

### DIFF
--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -2919,7 +2919,13 @@ func (ct *ColumnType) SQLType() querypb.Type {
 		return sqltypes.Float32
 	case keywordStrings[DOUBLE]:
 		return sqltypes.Float64
+	case keywordStrings[REAL]:
+		return sqltypes.Float64
 	case keywordStrings[DECIMAL]:
+		return sqltypes.Decimal
+	case keywordStrings[DEC]:
+		return sqltypes.Decimal
+	case keywordStrings[FIXED]:
 		return sqltypes.Decimal
 	case keywordStrings[BIT]:
 		return sqltypes.Bit

--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -2881,25 +2881,32 @@ func (ct *ColumnType) SQLType() querypb.Type {
 		return sqltypes.Int64
 	case keywordStrings[BOOL], keywordStrings[BOOLEAN]:
 		return sqltypes.Uint8
-	case keywordStrings[TEXT]:
+	case keywordStrings[TEXT],
+		keywordStrings[TINYTEXT],
+		keywordStrings[MEDIUMTEXT],
+		keywordStrings[LONGTEXT],
+		keywordStrings[LONG],
+		"long varchar":
 		return sqltypes.Text
-	case keywordStrings[TINYTEXT]:
-		return sqltypes.Text
-	case keywordStrings[MEDIUMTEXT]:
-		return sqltypes.Text
-	case keywordStrings[LONGTEXT]:
-		return sqltypes.Text
-	case keywordStrings[BLOB]:
+	case keywordStrings[BLOB],
+		keywordStrings[TINYBLOB],
+		keywordStrings[MEDIUMBLOB],
+		keywordStrings[LONGBLOB]:
 		return sqltypes.Blob
-	case keywordStrings[TINYBLOB]:
-		return sqltypes.Blob
-	case keywordStrings[MEDIUMBLOB]:
-		return sqltypes.Blob
-	case keywordStrings[LONGBLOB]:
-		return sqltypes.Blob
-	case keywordStrings[CHAR]:
+	case keywordStrings[CHAR],
+		keywordStrings[NCHAR],
+		"national char",
+		"national character":
 		return sqltypes.Char
-	case keywordStrings[VARCHAR]:
+	case keywordStrings[VARCHAR],
+		keywordStrings[NVARCHAR],
+		"char varying",
+		"character varying",
+		"nchar varchar",
+		"nchar varying",
+		"national varchar",
+		"national char varying",
+		"national character varying":
 		return sqltypes.VarChar
 	case keywordStrings[BINARY]:
 		return sqltypes.Binary
@@ -2917,15 +2924,14 @@ func (ct *ColumnType) SQLType() querypb.Type {
 		return sqltypes.Year
 	case keywordStrings[FLOAT_TYPE]:
 		return sqltypes.Float32
-	case keywordStrings[DOUBLE]:
+	case keywordStrings[DOUBLE],
+		keywordStrings[REAL],
+		"double precision":
 		return sqltypes.Float64
-	case keywordStrings[REAL]:
-		return sqltypes.Float64
-	case keywordStrings[DECIMAL]:
-		return sqltypes.Decimal
-	case keywordStrings[DEC]:
-		return sqltypes.Decimal
-	case keywordStrings[FIXED]:
+	case keywordStrings[DECIMAL],
+		keywordStrings[DEC],
+		keywordStrings[FIXED],
+		keywordStrings[NUMERIC]:
 		return sqltypes.Decimal
 	case keywordStrings[BIT]:
 		return sqltypes.Bit
@@ -2935,21 +2941,14 @@ func (ct *ColumnType) SQLType() querypb.Type {
 		return sqltypes.Set
 	case keywordStrings[JSON]:
 		return sqltypes.TypeJSON
-	case keywordStrings[GEOMETRY]:
-		return sqltypes.Geometry
-	case keywordStrings[POINT]:
-		return sqltypes.Geometry
-	case keywordStrings[LINESTRING]:
-		return sqltypes.Geometry
-	case keywordStrings[POLYGON]:
-		return sqltypes.Geometry
-	case keywordStrings[GEOMETRYCOLLECTION]:
-		return sqltypes.Geometry
-	case keywordStrings[MULTIPOINT]:
-		return sqltypes.Geometry
-	case keywordStrings[MULTILINESTRING]:
-		return sqltypes.Geometry
-	case keywordStrings[MULTIPOLYGON]:
+	case keywordStrings[GEOMETRY],
+		keywordStrings[POINT],
+		keywordStrings[LINESTRING],
+		keywordStrings[POLYGON],
+		keywordStrings[GEOMETRYCOLLECTION],
+		keywordStrings[MULTIPOINT],
+		keywordStrings[MULTILINESTRING],
+		keywordStrings[MULTIPOLYGON]:
 		return sqltypes.Geometry
 	}
 	panic("unimplemented type " + ct.Type)

--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -6786,6 +6786,9 @@ var (
 		input:  "create table t (id int primary key, col1 FIXED(4, 4) SRID 0)",
 		output: "cannot define SRID for non spatial types at position 61 near '0'",
 	}, {
+		input:  "create table t (id int primary key, col1 NCHAR VARCHAR SRID 0)",
+		output: "cannot define SRID for non spatial types at position 63 near '0'",
+	}, {
 		input:  "create table t (id int primary key, col1 geometry SRID -1)",
 		output: "syntax error at position 57 near 'SRID'",
 	}, {

--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -6777,6 +6777,15 @@ var (
 		input:  "create table t (id int primary key, col1 FLOAT SRID 0)",
 		output: "cannot define SRID for non spatial types at position 55 near '0'",
 	}, {
+		input:  "create table t (id int primary key, col1 REAL SRID 0)",
+		output: "cannot define SRID for non spatial types at position 54 near '0'",
+	}, {
+		input:  "create table t (id int primary key, col1 DEC(34, 2) SRID 0)",
+		output: "cannot define SRID for non spatial types at position 60 near '0'",
+	}, {
+		input:  "create table t (id int primary key, col1 FIXED(4, 4) SRID 0)",
+		output: "cannot define SRID for non spatial types at position 61 near '0'",
+	}, {
 		input:  "create table t (id int primary key, col1 geometry SRID -1)",
 		output: "syntax error at position 57 near 'SRID'",
 	}, {


### PR DESCRIPTION
This function is used when the parser needs to map type names to underlying types in order to judge the validity of certain queries. Some types are aliases for others, (like REAL is an alias for float64) but they weren't included in `SQLType()`, so certain expressions that used these types could panic.