### PR TITLE
custom `char()` syntax handling

### DIFF
--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -4762,6 +4762,7 @@ func (*ConvertExpr) iExpr()       {}
 func (*SubstrExpr) iExpr()        {}
 func (*TrimExpr) iExpr()          {}
 func (*ConvertUsingExpr) iExpr()  {}
+func (*CharExpr) iExpr()  {}
 func (*MatchExpr) iExpr()         {}
 func (*GroupConcatExpr) iExpr()   {}
 func (*Default) iExpr()           {}
@@ -5918,6 +5919,28 @@ func (node *ConvertUsingExpr) walkSubtree(visit Visit) error {
 
 func (node *ConvertUsingExpr) replace(from, to Expr) bool {
 	return replaceExprs(from, to, &node.Expr)
+}
+
+// CharExpr represents a call to CHAR(expr1, expr2, ... using charset)
+type CharExpr struct {
+	Exprs SelectExprs
+	Type  string
+}
+
+// Format formats the node.
+func (node *CharExpr) Format(buf *TrackedBuffer) {
+	buf.Myprintf("char(%v using %s)", node.Exprs, node.Type)
+}
+
+func (node *CharExpr) walkSubtree(visit Visit) error {
+	if node == nil {
+		return nil
+	}
+	return Walk(visit, node.Exprs)
+}
+
+func (node *CharExpr) replace(from, to Expr) bool {
+	return replaceExprs(from, to)
 }
 
 // ConvertType represents the type in call to CONVERT(expr, type)

--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -5929,7 +5929,11 @@ type CharExpr struct {
 
 // Format formats the node.
 func (node *CharExpr) Format(buf *TrackedBuffer) {
-	buf.Myprintf("char(%v using %s)", node.Exprs, node.Type)
+	if node.Type == "" {
+		buf.Myprintf("CHAR(%v)", node.Exprs)
+		return
+	}
+	buf.Myprintf("CHAR(%v USING %s)", node.Exprs, node.Type)
 }
 
 func (node *CharExpr) walkSubtree(visit Visit) error {

--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -5394,6 +5394,7 @@ func TestFunctionCalls(t *testing.T) {
 		"select WEIGHT_STRING() from dual",
 		"select YEAR() from dual",
 		"select YEARWEEK() from dual",
+		"select CHAR(77, 121, 83, 81, '76' USING utf8mb4) from dual",
 	}
 
 	// Functions where the input doesn't match the output. Prefer query tests above when possible.
@@ -5418,10 +5419,6 @@ func TestFunctionCalls(t *testing.T) {
 
 	// Unimplemented or broken functionality
 	skippedTestCases := []parseTest{
-		{
-			// USING syntax parsed but not captured
-			input: "select CHAR(77,121,83,81,'76' USING utf8mb4) from dual",
-		},
 		{
 			// INTERVAL function produces a grammar conflict
 			input: "select INTERVAL(col1, col2) from dual",

--- a/go/vt/sqlparser/sql.go
+++ b/go/vt/sqlparser/sql.go
@@ -19588,13 +19588,13 @@ yydefault:
 		yyDollar = yyS[yypt-4 : yypt+1]
 //line sql.y:6981
 		{
-			yyVAL.expr = &FuncExpr{Name: NewColIdent(string(yyDollar[1].bytes)), Exprs: yyDollar[3].selectExprs}
+			yyVAL.expr = &CharExpr{Exprs: yyDollar[3].selectExprs}
 		}
 	case 1419:
 		yyDollar = yyS[yypt-6 : yypt+1]
 //line sql.y:6985
 		{
-			yyVAL.expr = &FuncExpr{Name: NewColIdent(string(yyDollar[1].bytes)), Exprs: yyDollar[3].selectExprs}
+			yyVAL.expr = &CharExpr{Exprs: yyDollar[3].selectExprs, Type: yyDollar[5].str}
 		}
 	case 1420:
 		yyDollar = yyS[yypt-6 : yypt+1]

--- a/go/vt/sqlparser/sql.y
+++ b/go/vt/sqlparser/sql.y
@@ -6979,11 +6979,11 @@ function_call_keyword:
   }
 | CHAR openb argument_expression_list closeb
   {
-    $$ = &FuncExpr{Name: NewColIdent(string($1)), Exprs: $3}
+    $$ = &CharExpr{Exprs: $3}
   }
 | CHAR openb argument_expression_list USING charset closeb
   {
-    $$ = &FuncExpr{Name: NewColIdent(string($1)), Exprs: $3}
+    $$ = &CharExpr{Exprs: $3, Type: $5}
   }
 | CONVERT openb expression USING charset closeb
   {


### PR DESCRIPTION
In order to support the charset argument for `CHAR(... using <charset>)`, there has to be special syntax support.

Companion PR: https://github.com/dolthub/go-mysql-server/pull/2255