### PR TITLE
Super Type Demonstration

### DIFF
--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -2612,6 +2612,9 @@ type ColumnType struct {
 	// The base type string
 	Type string
 
+	// The base type if it has already been resolved
+	ResolvedType any
+
 	// Generic field options.
 	Null          BoolVal
 	NotNull       BoolVal
@@ -2758,17 +2761,19 @@ func (ct *ColumnType) merge(other ColumnType) error {
 
 // Format returns a canonical string representation of the type and all relevant options
 func (ct *ColumnType) Format(buf *TrackedBuffer) {
-	buf.Myprintf("%s", ct.Type)
+	if stringer, ok := ct.ResolvedType.(fmt.Stringer); ok {
+		buf.WriteString(stringer.String())
+	} else {
+		buf.Myprintf("%s", ct.Type)
+		if ct.Length != nil && ct.Scale != nil {
+			buf.Myprintf("(%v,%v)", ct.Length, ct.Scale)
 
-	if ct.Length != nil && ct.Scale != nil {
-		buf.Myprintf("(%v,%v)", ct.Length, ct.Scale)
-
-	} else if ct.Length != nil {
-		buf.Myprintf("(%v)", ct.Length)
-	}
-
-	if len(ct.EnumValues) > 0 {
-		buf.Myprintf("('%s')", strings.Join(ct.EnumValues, "', '"))
+		} else if ct.Length != nil {
+			buf.Myprintf("(%v)", ct.Length)
+		}
+		if len(ct.EnumValues) > 0 {
+			buf.Myprintf("('%s')", strings.Join(ct.EnumValues, "', '"))
+		}
 	}
 
 	opts := make([]string, 0, 16)
@@ -7210,4 +7215,24 @@ func (node *SrsAttribute) Format(buf *TrackedBuffer) {
 	buf.Myprintf("definition '%s'\n", node.Definition)
 	buf.Myprintf("organization '%s' identified by %v\n", node.Organization, node.OrgID)
 	buf.Myprintf("description '%s'", node.Description)
+}
+
+type DoltgresInjectedExpr struct {
+	Expression any
+}
+
+var _ Expr = DoltgresInjectedExpr{}
+
+func (d DoltgresInjectedExpr) iExpr() {}
+
+func (d DoltgresInjectedExpr) replace(from, to Expr) bool {
+	return false
+}
+
+func (d DoltgresInjectedExpr) Format(buf *TrackedBuffer) {
+	if stringer, ok := d.Expression.(fmt.Stringer); ok {
+		buf.WriteString(stringer.String())
+	} else {
+		buf.WriteString("DoltgresInjectedExpr")
+	}
 }


### PR DESCRIPTION
This is the Vitess side of the _super type_ demonstration implementation. This serves as a sort of "implementation guide" to see what kinds of changes a _super type_ could potentially need. For Vitess, Doltgres will need a way to inject arbitrary expressions into the AST, since the Vitess AST is being used as an intermediate format. Currently, all nodes are for specific actions that aren't necessarily able to be generalized across SQL implementations (that is, anything that isn't MySQL). Doltgres needs to be able to add its own nodes without needing to add everything to Vitess, and Vitess should remain focused on MySQL syntax.

The best solution would require a new AST format that's generic to all SQL implementations (something like assembly being applicable to all programming languages), so this is sort of a "step 1" toward that goal.