### PR TITLE
Changes to binlog event creation functions

### DIFF
--- a/go/mysql/binlog_event.go
+++ b/go/mysql/binlog_event.go
@@ -81,6 +81,8 @@ type BinlogEvent interface {
 
 	// Timestamp returns the timestamp from the event header.
 	Timestamp() uint32
+	// Length returns the size in bytes of this binlog event from the event header.
+	Length() uint32
 
 	// Format returns a BinlogFormat struct based on the event data.
 	// This is only valid if IsFormatDescription() returns true.

--- a/go/mysql/binlog_event_filepos.go
+++ b/go/mysql/binlog_event_filepos.go
@@ -177,6 +177,10 @@ func (ev filePosFakeEvent) Timestamp() uint32 {
 	return ev.timestamp
 }
 
+func (ev filePosFakeEvent) Length() uint32 {
+	return 0
+}
+
 func (ev filePosFakeEvent) Format() (BinlogFormat, error) {
 	return BinlogFormat{}, nil
 }


### PR DESCRIPTION
* Exposing the `Length()` function in the BinlogEvent interface so calling code can access the event size present in a binlog event's header. Needed for calculating binlog file position. 
* Renaming `FakeBinlogStream` → `BinlogStream` so calling code can use it when serializing binlog events.