### PR TITLE
Consistently using pointer to AliasedValues in InsertRows interface, never values.

### DIFF
--- a/go/vt/sqlparser/sql.go
+++ b/go/vt/sqlparser/sql.go
@@ -12125,7 +12125,7 @@ yydefault:
 				cols = append(cols, updateList.Name.Name)
 				vals = append(vals, updateList.Expr)
 			}
-			yyVAL.statement = &Insert{Action: yyDollar[2].str, Comments: Comments(yyDollar[3].bytes2), Ignore: yyDollar[4].str, Table: yyDollar[5].tableName, Partitions: yyDollar[6].partitions, Columns: cols, Rows: AliasedValues{Values: Values{vals}}, OnDup: OnDup(yyDollar[9].assignExprs), With: yyDollar[1].with}
+			yyVAL.statement = &Insert{Action: yyDollar[2].str, Comments: Comments(yyDollar[3].bytes2), Ignore: yyDollar[4].str, Table: yyDollar[5].tableName, Partitions: yyDollar[6].partitions, Columns: cols, Rows: &AliasedValues{Values: Values{vals}}, OnDup: OnDup(yyDollar[9].assignExprs), With: yyDollar[1].with}
 		}
 	case 80:
 		yyDollar = yyS[yypt-1 : yypt+1]
@@ -21007,8 +21007,8 @@ yydefault:
 //line sql.y:7847
 		{
 			yyVAL.ins = yyDollar[1].ins
-			// Rows is guarenteed to be an AliasedValues here.
-			rows := yyVAL.ins.Rows.(AliasedValues)
+			// Rows is guarenteed to be an *AliasedValues here.
+			rows := yyVAL.ins.Rows.(*AliasedValues)
 			rows.As = yyDollar[3].tableIdent
 			if yyDollar[4].columns != nil {
 				rows.Columns = yyDollar[4].columns
@@ -21063,13 +21063,13 @@ yydefault:
 		yyDollar = yyS[yypt-4 : yypt+1]
 //line sql.y:7901
 		{
-			yyVAL.ins = &Insert{Columns: []ColIdent{}, Rows: AliasedValues{Values: yyDollar[4].values}}
+			yyVAL.ins = &Insert{Columns: []ColIdent{}, Rows: &AliasedValues{Values: yyDollar[4].values}}
 		}
 	case 1620:
 		yyDollar = yyS[yypt-5 : yypt+1]
 //line sql.y:7906
 		{
-			yyVAL.ins = &Insert{Columns: yyDollar[2].columns, Rows: AliasedValues{Values: yyDollar[5].values}}
+			yyVAL.ins = &Insert{Columns: yyDollar[2].columns, Rows: &AliasedValues{Values: yyDollar[5].values}}
 		}
 	case 1623:
 		yyDollar = yyS[yypt-0 : yypt+1]

--- a/go/vt/sqlparser/sql.y
+++ b/go/vt/sqlparser/sql.y
@@ -943,7 +943,7 @@ insert_statement:
       cols = append(cols, updateList.Name.Name)
       vals = append(vals, updateList.Expr)
     }
-    $$ = &Insert{Action: $2, Comments: Comments($3), Ignore: $4, Table: $5, Partitions: $6, Columns: cols, Rows: AliasedValues{Values: Values{vals}}, OnDup: OnDup($9), With: $1}
+    $$ = &Insert{Action: $2, Comments: Comments($3), Ignore: $4, Table: $5, Partitions: $6, Columns: cols, Rows: &AliasedValues{Values: Values{vals}}, OnDup: OnDup($9), With: $1}
   }
 
 insert_or_replace:
@@ -7846,8 +7846,8 @@ insert_data_alias:
 | insert_data_values as_opt table_alias column_list_opt
   {
     $$ = $1
-    // Rows is guarenteed to be an AliasedValues here.
-    rows := $$.Rows.(AliasedValues)
+    // Rows is guarenteed to be an *AliasedValues here.
+    rows := $$.Rows.(*AliasedValues)
     rows.As = $3
     if $4 != nil {
         rows.Columns = $4
@@ -7899,12 +7899,12 @@ insert_data_values:
   }
 | openb closeb value_or_values tuple_list
   {
-    $$ = &Insert{Columns: []ColIdent{}, Rows: AliasedValues{Values: $4}}
+    $$ = &Insert{Columns: []ColIdent{}, Rows: &AliasedValues{Values: $4}}
   }
 
 | openb ins_column_list closeb value_or_values tuple_list
   {
-    $$ = &Insert{Columns: $2, Rows: AliasedValues{Values: $5}}
+    $$ = &Insert{Columns: $2, Rows: &AliasedValues{Values: $5}}
   }
 
 value_or_values:


### PR DESCRIPTION
Once again, golang reminds me that a value type implementing an interface forces the pointer type to also implement the interface, and mixing the two messes up our runtime type reflection.

I changed all uses of the AliasedValues in InsertRows interface to be pointers so that we can interact with them consistently on the GMS side.