### PR TITLE
Exposing binary JSON encoding to SQL expression logic for testing

### DIFF
--- a/go/mysql/binlog_event_json.go
+++ b/go/mysql/binlog_event_json.go
@@ -50,6 +50,20 @@ const (
 	jsonFalseLiteral = '\x02'
 )
 
+// ConvertBinaryJSONToSQL converts the specified |data| in MySQL's internal binary encoding
+// to a SQL expression that can be evaluated.
+func ConvertBinaryJSONToSQL(data []byte) (string, error) {
+	bytes, err := printJSONData(data)
+	if err != nil {
+		return "", err
+	}
+
+	if bytes == nil {
+		return "", nil
+	}
+	return string(bytes), nil
+}
+
 // printJSONData parses the MySQL binary format for JSON data, and prints
 // the result as a string.
 func printJSONData(data []byte) ([]byte, error) {


### PR DESCRIPTION
Exposing logic in Vitess that decodes MySQL's internal, binary JSON serialization encoding, so that we can use it to test JSON serialization.