### PR TITLE
Add `ConnectionAborted()` callback to `Handler` interface

### DIFF
--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -18,6 +18,7 @@ package mysql
 
 import (
 	"crypto/tls"
+	"fmt"
 	"io"
 	"net"
 	"strings"
@@ -89,6 +90,12 @@ type Handler interface {
 
 	// ConnectionClosed is called when a connection is closed.
 	ConnectionClosed(c *Conn)
+
+	// ConnectionAborted is called when a new connection cannot be fully established. For
+	// example, if a client connects to the server, but fails authentication, or can't
+	// negotiate an authentication handshake, this method will be called to let integrators
+	// know about the failed connection attempt.
+	ConnectionAborted(c *Conn, reason string) error
 
 	// ComInitDB is called once at the beginning to set db name,
 	// and subsequently for every ComInitDB event.
@@ -362,7 +369,7 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Ti
 	salt, err := c.writeHandshakeV10(l.ServerVersion, l.authServer, l.TLSConfig != nil)
 	if err != nil {
 		if err != io.EOF {
-			log.Errorf("Cannot send HandshakeV10 packet to %s: %v", c, err)
+			l.handleConnectionError(c, fmt.Sprintf("Cannot send HandshakeV10 packet: %v", err))
 		}
 		return
 	}
@@ -373,13 +380,16 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Ti
 	if err != nil {
 		// Don't log EOF errors. They cause too much spam, same as main read loop.
 		if err != io.EOF {
-			log.Infof("Cannot read client handshake response from %s: %v, it may not be a valid MySQL client", c, err)
+			l.handleConnectionWarning(c, fmt.Sprintf(
+				"Cannot read client handshake response from %s: %v, " +
+					"it may not be a valid MySQL client", c, err))
 		}
 		return
 	}
 	user, authMethod, authResponse, err := l.parseClientHandshakePacket(c, true, response)
 	if err != nil {
-		log.Errorf("Cannot parse client handshake response from %s: %v", c, err)
+		l.handleConnectionError(c, fmt.Sprintf(
+			"Cannot parse client handshake response from %s: %v", c, err))
 		return
 	}
 
@@ -389,14 +399,16 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Ti
 		// SSL was enabled. We need to re-read the auth packet.
 		response, err = c.readEphemeralPacket()
 		if err != nil {
-			log.Errorf("Cannot read post-SSL client handshake response from %s: %v", c, err)
+			l.handleConnectionError(c, fmt.Sprintf(
+				"Cannot read post-SSL client handshake response from %s: %v", c, err))
 			return
 		}
 
 		// Returns copies of the data, so we can recycle the buffer.
 		user, authMethod, authResponse, err = l.parseClientHandshakePacket(c, false, response)
 		if err != nil {
-			log.Errorf("Cannot parse post-SSL client handshake response from %s: %v", c, err)
+			l.handleConnectionError(c, fmt.Sprintf(
+				"Cannot parse post-SSL client handshake response from %s: %v", c, err))
 			return
 		}
 		c.recycleReadPacket()
@@ -420,6 +432,7 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Ti
 	// See what auth method the AuthServer wants to use for that user.
 	authServerMethod, err := l.authServer.AuthMethod(user, conn.RemoteAddr().String())
 	if err != nil {
+		l.handleConnectionError(c, "auth server failed to determine auth method")
 		c.writeErrorPacketFromError(err)
 		return
 	}
@@ -432,7 +445,8 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Ti
 		// ValidateHash() method.
 		userData, err := l.authServer.ValidateHash(salt, user, authResponse, conn.RemoteAddr())
 		if err != nil {
-			log.Warningf("Error authenticating user using MySQL native password: %v", err)
+			l.handleConnectionWarning(c, fmt.Sprintf(
+				"Error authenticating user using MySQL native password: %v", err))
 			c.writeErrorPacketFromError(err)
 			return
 		}
@@ -451,20 +465,22 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Ti
 		data := make([]byte, 21)
 		data = append(salt, byte(0x00))
 		if err := c.writeAuthSwitchRequest(MysqlNativePassword, data); err != nil {
-			log.Errorf("Error writing auth switch packet for %s: %v", c, err)
+			l.handleConnectionError(c, fmt.Sprintf("Error writing auth switch packet for %s: %v", c, err))
 			return
 		}
 
 		response, err := c.readEphemeralPacket()
 		if err != nil {
-			log.Errorf("Error reading auth switch response for %s: %v", c, err)
+			l.handleConnectionError(c, fmt.Sprintf(
+				"Error reading auth switch response for %s: %v", c, err))
 			return
 		}
 		c.recycleReadPacket()
 
 		userData, err := l.authServer.ValidateHash(salt, user, response, conn.RemoteAddr())
 		if err != nil {
-			log.Warningf("Error authenticating user using MySQL native password: %v", err)
+			l.handleConnectionWarning(c, fmt.Sprintf(
+				"Error authenticating user using MySQL native password: %v", err))
 			c.writeErrorPacketFromError(err)
 			return
 		}
@@ -476,6 +492,8 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Ti
 
 		// The negotiation happens in clear text. Let's check we can.
 		if !l.AllowClearTextWithoutTLS.Get() && c.Capabilities&CapabilityClientSSL == 0 {
+			l.handleConnectionWarning(c, fmt.Sprintf(
+				"Cannot use clear text authentication over non-SSL connections."))
 			c.writeErrorPacket(CRServerHandshakeErr, SSUnknownSQLState, "Cannot use clear text authentication over non-SSL connections.")
 			return
 		}
@@ -487,7 +505,8 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Ti
 			data = authServerDialogSwitchData()
 		}
 		if err := c.writeAuthSwitchRequest(authServerMethod, data); err != nil {
-			log.Errorf("Error writing auth switch packet for %s: %v", c, err)
+			l.handleConnectionError(c, fmt.Sprintf(
+				"Error writing auth switch packet for %s: %v", c, err))
 			return
 		}
 
@@ -495,6 +514,8 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Ti
 		// auth server.
 		userData, err := l.authServer.Negotiate(c, user, conn.RemoteAddr())
 		if err != nil {
+			l.handleConnectionWarning(c, fmt.Sprintf(
+				"Unable to negotiate authentication: %v", err))
 			c.writeErrorPacketFromError(err)
 			return
 		}
@@ -538,6 +559,23 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Ti
 		}
 	}
 }
+
+// handleConnectionError logs |reason| as an error and notifies the handler that a connection has been aborted.
+func (l *Listener) handleConnectionError(c *Conn, reason string) {
+	log.Error(reason)
+	if err := l.handler.ConnectionAborted(c, reason); err != nil {
+		log.Errorf("unable to report connection aborted to handler: %s", err)
+	}
+}
+
+// handleConnectionWarning logs |reason| as a warning and notifies the handler that a connection has been aborted.
+func (l *Listener) handleConnectionWarning(c *Conn, reason string) {
+	log.Warning(reason)
+	if err := l.handler.ConnectionAborted(c, reason); err != nil {
+		log.Errorf("unable to report connection aborted to handler: %s", err)
+	}
+}
+
 
 // Close stops the listener, which prevents accept of any new connections. Existing connections won't be closed.
 func (l *Listener) Close() {

--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -114,6 +114,10 @@ func (th *testHandler) NewConnection(c *Conn) {
 func (th *testHandler) ConnectionClosed(c *Conn) {
 }
 
+func (th *testHandler) ConnectionAborted(c *Conn, reason string) error {
+	return nil
+}
+
 func (th *testHandler) ParserOptionsForConnection(c *Conn) (sqlparser.ParserOptions, error) {
 	return sqlparser.ParserOptions{}, nil
 }


### PR DESCRIPTION
In order to support [the `Aborted_connects` status variable](https://dev.mysql.com/doc/refman/8.4/en/server-status-variables.html#statvar_Aborted_connects), GMS needs to be notified when a connection attempt is aborted in the Vitess layer. This change adds a `ConnectionAborted()` callback method to Vitess' `Handler` interface and calls it whenever a connection attempt errors out before it's fully established. 

Coordinated with https://github.com/dolthub/go-mysql-server/pull/2546