### PR TITLE
Bug fix: Off-by-one error when parsing multiple statements

### DIFF
--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -149,7 +149,7 @@ func ParseOneWithOptions(ctx context.Context, sql string, options ParserOptions)
 		}
 	}
 
-	return tree, tokenizer.Position, nil
+	return tree, tokenizer.Position-1, nil
 }
 
 func parseTokenizer(sql string, tokenizer *Tokenizer) (Statement, error) {

--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -4662,6 +4662,10 @@ func TestParseOne(t *testing.T) {
 	}
 	cases := []tc{
 		{
+			"select 1;select 64 * 10;",
+			"select 64 * 10;",
+		},
+		{
 			"select 1; select 64 * 10;",
 			"select 64 * 10;",
 		},
@@ -4722,6 +4726,7 @@ func TestParseOne(t *testing.T) {
 			var rest string
 			if resti < len(c.input) {
 				rest = c.input[resti:]
+				rest = strings.Trim(rest, " \n")
 			}
 			require.Equal(t, c.remainder, rest)
 		})
@@ -5134,7 +5139,7 @@ end`,
 		t.Run(tcase.query+" ParseOne", func(t *testing.T) {
 			tree, remainder, err := ParseOne(context.Background(), tcase.query)
 			require.Nil(t, err)
-			require.Equal(t, len(tcase.query)+1, remainder)
+			require.Equal(t, len(tcase.query), remainder)
 
 			ddl, ok := tree.(*DDL)
 			require.True(t, ok, "Expected DDL when parsing (%q)", tcase.query)


### PR DESCRIPTION
An off-by-one error in multistatement parsing prevents us from parsing multistatements without a space between the delimiter and the next statement. For example: "SELECT 1;SELECT 2;" would previously be parsed as "SELECT 1;S" and "ELECT 2;". 

Found while testing changes for https://github.com/dolthub/driver/issues/28