### PR TITLE
Bug fix: Send an error response when the server fails to handle `COM_BINLOG_DUMP_GTID`

### DIFF
--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -1464,6 +1464,7 @@ func (c *Conn) handleComBinlogDumpGTID(handler Handler, data []byte) (kontinue b
 	}
 	if err := binlogReplicaHandler.ComBinlogDumpGTID(c, logFile, logPos, position.GTIDSet); err != nil {
 		log.Error(err.Error())
+		c.writeErrorPacketFromError(err)
 		return false
 	}
 	return kontinue


### PR DESCRIPTION
A MySQL primary needs to be able to send back an error response when handling the `COM_BINLOG_DUMP_GTID` command. Previously, when the integrator returned an error, it was logged in the primary server logs, but it was not being sent back to the replica who sent the command. This change causes an error packet to be sent to the replica, containing the details of the error the integrator returned. 

This change is difficult to test in isolation, but I have tests in `dolt` that will exercise this codepath. 