### PR TITLE
fix detection of multi-statements in `ComPrepare`

### DIFF
--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -1125,7 +1125,7 @@ func (c *Conn) handleNextCommand(ctx context.Context, handler Handler) error {
 				}
 			}
 			if len(queries) != 1 {
-				err := fmt.Errorf("can not prepare multiple statements")
+				err := fmt.Errorf("cannot prepare multiple statements")
 				if werr := c.writeErrorPacketFromError(err); werr != nil {
 					// If we can't even write the error, we're done.
 					log.Errorf("Error writing query error to %s: %v", c, werr)

--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -1123,6 +1123,7 @@ func (c *Conn) handleNextCommand(ctx context.Context, handler Handler) error {
 					log.Errorf("Error writing query error to %s: %v", c, werr)
 					return werr
 				}
+				return nil
 			}
 			if len(queries) != 1 {
 				err := fmt.Errorf("cannot prepare multiple statements")
@@ -1131,6 +1132,7 @@ func (c *Conn) handleNextCommand(ctx context.Context, handler Handler) error {
 					log.Errorf("Error writing query error to %s: %v", c, werr)
 					return werr
 				}
+				return nil
 			}
 		} else {
 			queries = []string{query}

--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -1105,43 +1105,47 @@ func (c *Conn) handleNextCommand(ctx context.Context, handler Handler) error {
 			return nil
 		}
 
-		// Populate PrepareData
-		c.StatementID++
-		prepare := &PrepareData{
-			StatementID: c.StatementID,
-			PrepareStmt: query,
-		}
-
 		var err error
 		var statement sqlparser.Statement
-		var remainder string
-
 		parserOptions, err := handler.ParserOptionsForConnection(c)
 		if err != nil {
 			log.Errorf("unable to determine parser options for current connection: %s", err.Error())
 			return err
 		}
 
+		var queries []string
 		if !c.DisableClientMultiStatements && c.Capabilities&CapabilityClientMultiStatements != 0 {
-			var ri int
-			statement, ri, err = sqlparser.ParseOneWithOptions(ctx, query, parserOptions)
-			if ri < len(query) {
-				remainder = query[ri:]
+			queries, err = sqlparser.SplitStatementToPieces(query)
+			if err != nil {
+				log.Errorf("error splitting query: %v", c, err)
+				if werr := c.writeErrorPacketFromError(err); werr != nil {
+					// If we can't even write the error, we're done.
+					log.Errorf("Error writing query error to %s: %v", c, werr)
+					return werr
+				}
+			}
+			if len(queries) != 1 {
+				err := fmt.Errorf("can not prepare multiple statements")
+				if werr := c.writeErrorPacketFromError(err); werr != nil {
+					// If we can't even write the error, we're done.
+					log.Errorf("Error writing query error to %s: %v", c, werr)
+					return werr
+				}
 			}
 		} else {
-			statement, err = sqlparser.ParseWithOptions(ctx, query, parserOptions)
+			queries = []string{query}
 		}
+
+		// Populate PrepareData
+		c.StatementID++
+		prepare := &PrepareData{
+			StatementID: c.StatementID,
+			PrepareStmt: queries[0],
+		}
+
+		statement, err = sqlparser.ParseWithOptions(ctx, query, parserOptions)
 		if err != nil {
 			log.Errorf("Error while parsing prepared statement: %s", err.Error())
-			if werr := c.writeErrorPacketFromError(err); werr != nil {
-				// If we can't even write the error, we're done.
-				log.Errorf("Error writing query error to %s: %v", c, werr)
-				return werr
-			}
-			return nil
-		}
-		if remainder != "" {
-			err := fmt.Errorf("can not prepare multiple statements")
 			if werr := c.writeErrorPacketFromError(err); werr != nil {
 				// If we can't even write the error, we're done.
 				log.Errorf("Error writing query error to %s: %v", c, werr)

--- a/go/mysql/query_test.go
+++ b/go/mysql/query_test.go
@@ -1116,38 +1116,6 @@ func TestExecuteQueries(t *testing.T) {
 	})
 }
 
-func MockPrepareData2(t *testing.T) (*PrepareData, *sqltypes.Result) {
-	sql := "select ?"
-
-	result := &sqltypes.Result{
-		Fields: []*querypb.Field{
-			{
-				Name: "id",
-				Type: querypb.Type_INT32,
-			},
-		},
-		Rows: [][]sqltypes.Value{
-			{
-				sqltypes.MakeTrusted(querypb.Type_INT32, []byte("1")),
-			},
-		},
-		RowsAffected: 1,
-	}
-
-	prepare := &PrepareData{
-		StatementID: 18,
-		PrepareStmt: sql,
-		ParamsCount: 1,
-		ParamsType:  []int32{263},
-		ColumnNames: []string{"id"},
-		BindVars: map[string]*querypb.BindVariable{
-			"v1": sqltypes.Int32BindVariable(10),
-		},
-	}
-
-	return prepare, result
-}
-
 func TestComPrepareMultiple(t *testing.T) {
 	listener, sConn, cConn := createSocketPair(t)
 	defer func() {


### PR DESCRIPTION
Currently, preparing multi-statements is not supported; so we can't prepare a query like `select ?; select ?;`.
However, the check for this condition just looked for any characters after the first `;`, which meant that queries like `select ?; \n` would incorrectly throw an error. 

This was made apparent using the Prisma ORM, which runs the query:
```sql
SELECT TABLE_NAME AS view_name, VIEW_DEFINITION AS view_sql
FROM INFORMATION_SCHEMA.VIEWS
WHERE TABLE_SCHEMA = ?;

```
The above query ends in a newline character.

The fix is to use `SplitStatementToPieces()`, which trims these white space characters, and check if there's exactly one piece; this was taken from the vitessio repo: https://github.com/vitessio/vitess/blob/main/go/mysql/conn.go#L1204

fixes https://github.com/dolthub/dolt/issues/8157
