### PR TITLE
Bug fix: Preserve sign for integers in prepared statements

### DIFF
--- a/go/mysql/query.go
+++ b/go/mysql/query.go
@@ -700,7 +700,7 @@ func (c *Conn) parseStmtArgs(data []byte, typ querypb.Type, pos int) (sqltypes.V
 		return sqltypes.NULL, pos, true
 	case sqltypes.Int8:
 		val, pos, ok := readByte(data, pos)
-		return sqltypes.NewInt64(int64(val)), pos, ok
+		return sqltypes.NewInt64(int64(int8(val))), pos, ok
 	case sqltypes.Uint8:
 		val, pos, ok := readByte(data, pos)
 		return sqltypes.NewUint64(uint64(val)), pos, ok
@@ -709,13 +709,13 @@ func (c *Conn) parseStmtArgs(data []byte, typ querypb.Type, pos int) (sqltypes.V
 		return sqltypes.NewUint64(uint64(val)), pos, ok
 	case sqltypes.Int16, sqltypes.Year:
 		val, pos, ok := readUint16(data, pos)
-		return sqltypes.NewInt64(int64(val)), pos, ok
+		return sqltypes.NewInt64(int64(int16(val))), pos, ok
 	case sqltypes.Uint24, sqltypes.Uint32:
 		val, pos, ok := readUint32(data, pos)
 		return sqltypes.NewUint64(uint64(val)), pos, ok
 	case sqltypes.Int24, sqltypes.Int32:
 		val, pos, ok := readUint32(data, pos)
-		return sqltypes.NewInt64(int64(val)), pos, ok
+		return sqltypes.NewInt64(int64(int32(val))), pos, ok
 	case sqltypes.Float32:
 		val, pos, ok := readUint32(data, pos)
 		return sqltypes.NewFloat64(float64(math.Float32frombits(uint32(val)))), pos, ok


### PR DESCRIPTION
Bound integer values for prepared statements are parsed from the wire and packaged into `int64` values that are then passed to the SQL engine to execute with the prepared statement. For `int8`, `int16`, `int24`, and `int32` types those bytes from the wire weren't getting cast to the correct type first, before they were cast to `int64`, which meant if the signed bit was set, the value was interpreted incorrectly. 

Customer issue: https://github.com/dolthub/dolt/issues/8085