### PR TITLE
Added schema name to show table opts

### DIFF
--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -3918,6 +3918,7 @@ func (node *Show) walkSubtree(visit Visit) error {
 // ShowTablesOpt is show tables option
 type ShowTablesOpt struct {
 	DbName string
+	SchemaName string
 	Filter *ShowFilter
 	AsOf   Expr
 }
@@ -3927,9 +3928,15 @@ func (node *ShowTablesOpt) Format(buf *TrackedBuffer) {
 	if node == nil {
 		return
 	}
-	if node.DbName != "" {
+	
+	if node.SchemaName != "" && node.DbName != "" { 
+		buf.Myprintf(" from %s.%s", node.DbName, node.SchemaName)
+	} else if node.DbName != "" {
 		buf.Myprintf(" from %s", node.DbName)
+	} else if node.SchemaName != "" {
+		buf.Myprintf(" from %s", node.SchemaName)
 	}
+	
 	if node.AsOf != nil {
 		buf.Myprintf(" as of ")
 		node.AsOf.Format(buf)


### PR DESCRIPTION
No way to populate this field from the parser directly, must be set manually when generating the AST via other means.