### PR TITLE
Remove patch version from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dolthub/vitess
 
-go 1.23.3
+go 1.23
 
 require (
 	github.com/google/go-cmp v0.5.5


### PR DESCRIPTION
Having the patch version can make use of this a little more complex - as it requires all users to ensure they have a least the same patch version.

It does make sense to keep the minor version current so that the latest go features can be used - but having the patch version shouldn't make any difference to the library.

This was changed in the following PR from `1.22` to `1.23.3` https://github.com/dolthub/vitess/pull/385.