### PR TITLE
go/mysql: conn.go: Fix read-after-recycle bug of the packet byte buffer in COM_{STMT_SEND_LONG_DATA,REGISTER_REPLICA,BINLOG_DUMP_GTID}.

### DIFF
--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -1424,13 +1424,14 @@ func (c *Conn) handleComRegisterReplica(handler Handler, data []byte) (kontinue 
 		return true
 	}
 
-	c.recycleReadPacket()
-
 	replicaHost, replicaPort, replicaUser, replicaPassword, err := c.parseComRegisterReplica(data)
 	if err != nil {
 		log.Errorf("conn %v: parseComRegisterReplica failed: %v", c.ID(), err)
 		return false
 	}
+
+	c.recycleReadPacket()
+
 	if err := binlogReplicaHandler.ComRegisterReplica(c, replicaHost, replicaPort, replicaUser, replicaPassword); err != nil {
 		c.writeErrorPacketFromError(err)
 		return false
@@ -1449,7 +1450,6 @@ func (c *Conn) handleComBinlogDumpGTID(handler Handler, data []byte) (kontinue b
 		return true
 	}
 
-	c.recycleReadPacket()
 	kontinue = true
 
 	c.startWriterBuffering()
@@ -1465,6 +1465,7 @@ func (c *Conn) handleComBinlogDumpGTID(handler Handler, data []byte) (kontinue b
 		log.Errorf("conn %v: parseComBinlogDumpGTID failed: %v", c.ID(), err)
 		return false
 	}
+	c.recycleReadPacket()
 	if err := binlogReplicaHandler.ComBinlogDumpGTID(c, logFile, logPos, position.GTIDSet); err != nil {
 		log.Error(err.Error())
 		c.writeErrorPacketFromError(err)

--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -1236,7 +1236,7 @@ func (c *Conn) handleNextCommand(ctx context.Context, handler Handler) error {
 			return err
 		}
 	case ComStmtSendLongData:
-		stmtID, paramID, chunkData, ok := c.parseComStmtSendLongData(data)
+		stmtID, paramID, chunk, ok := c.parseComStmtSendLongData(data)
 		c.recycleReadPacket()
 		if !ok {
 			err := fmt.Errorf("error parsing statement send long data from client %v, returning error: %v", c.ConnectionID, data)
@@ -1258,9 +1258,6 @@ func (c *Conn) handleNextCommand(ctx context.Context, handler Handler) error {
 			log.Error(err.Error())
 			return err
 		}
-
-		chunk := make([]byte, len(chunkData))
-		copy(chunk, chunkData)
 
 		key := fmt.Sprintf("v%d", paramID+1)
 		if val, ok := prepare.BindVars[key]; ok {

--- a/go/mysql/query.go
+++ b/go/mysql/query.go
@@ -933,7 +933,11 @@ func (c *Conn) parseComStmtSendLongData(data []byte) (uint32, uint16, []byte, bo
 		return 0, 0, nil, false
 	}
 
-	return statementID, paramID, data[pos:], true
+	chunkData := data[pos:]
+	chunk := make([]byte, len(chunkData))
+	copy(chunk, chunkData)
+
+	return statementID, paramID, chunk, true
 }
 
 func (c *Conn) parseComStmtClose(data []byte) (uint32, bool) {


### PR DESCRIPTION
Back ports https://github.com/vitessio/vitess/commit/24820d8101688019d4c83b64d911778450255687