### PR TITLE
Log a warning when max connections is hit

### DIFF
--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -324,7 +324,13 @@ func (l *Listener) Accept() {
 		connectionID := l.connectionID
 		l.connectionID++
 
+		maxConWarn := false
 		for l.maxConns > 0 && uint64(connCount.Get()) >= l.maxConns {
+			if !maxConWarn {
+				log.Warning("max connections reached. Clients waiting. Increase server max connections")
+				maxConWarn = true // Logging once for each connection seems adequate.
+			}
+
 			// TODO: make this behavior configurable (wait v. reject)
 			time.Sleep(500 * time.Millisecond)
 		}


### PR DESCRIPTION
Fixes: https://github.com/dolthub/dolt/issues/8942

Tested by configuring a server with 2 max conns, then connecting to it 3 times:
```
lcl:~/Documents/data_dir_1/db3$ dolt sql-server --config ./config.yaml
Starting server with Config HP="localhost:3306"|T="28800000"|R="false"|L="info"|S="/tmp/mysql.sock"
WARN[0000] unix socket set up failed: file already in use: /tmp/mysql.sock
INFO[0000] Server ready. Accepting connections.
WARN[0000] secure_file_priv is set to "", which is insecure.
WARN[0000] Any user with GRANT FILE privileges will be able to read any file which the sql-server process can read.
WARN[0000] Please consider restarting the server with secure_file_priv set to a safe (or non-existent) directory.
INFO[0004] NewConnection                                 DisableClientMultiStatements=false connectionID=1
INFO[0006] NewConnection                                 DisableClientMultiStatements=false connectionID=2
WARN[0009] max connections reached. Clients waiting. Increase server max connections
```