### PR TITLE
fix up constants for server cursor types and add a support for `PARAMETER_COUNT_AVAILABLE` cursor

### DIFF
--- a/go/mysql/constants.go
+++ b/go/mysql/constants.go
@@ -170,10 +170,11 @@ const (
 // Cursor Types. They are received on COM_STMT_EXECUTE()
 // See https://mariadb.com/kb/en/com_stmt_execute/
 const (
-	NoCursor = iota
-	ReadOnly
-	CursorForUpdate
-	ScrollableCursor
+	NoCursor uint8 = 0x00
+	ReadOnly uint8 = 0x01
+	CursorForUpdate uint8 = 0x02
+	ScrollableCursor uint8 = 0x04
+	ParameterCountAvailable uint8 = 0x08
 )
 
 // State Change Information

--- a/go/mysql/constants.go
+++ b/go/mysql/constants.go
@@ -168,12 +168,12 @@ const (
 )
 
 // Cursor Types. They are received on COM_STMT_EXECUTE()
-// See https://mariadb.com/kb/en/com_stmt_execute/
+// See https://dev.mysql.com/doc/dev/mysql-server/9.3.0/mysql__com_8h.html#a3e5e9e744ff6f7b989a604fd669977da
 const (
 	NoCursor uint8 = 0x00
 	ReadOnly uint8 = 0x01
-	CursorForUpdate uint8 = 0x02
-	ScrollableCursor uint8 = 0x04
+	ForUpdate uint8 = 0x02
+	Scrollable uint8 = 0x04
 	ParameterCountAvailable uint8 = 0x08
 )
 


### PR DESCRIPTION
We were missing the `PARAMETER_COUNT_AVAILABLE` server cursor type when handling a `COM_STMT_EXECUTE`.
Oddly, it seems to behave as if there were no cursor.

MySQL Docs: https://dev.mysql.com/doc/dev/mysql-server/9.3.0/mysql__com_8h.html#a3e5e9e744ff6f7b989a604fd669977da
Fixes: https://github.com/dolthub/dolt/issues/9313