### PR TITLE
Length-encode vector values when sent on the wire.

### DIFF
--- a/go/mysql/query.go
+++ b/go/mysql/query.go
@@ -1548,7 +1548,7 @@ func val2MySQL(v sqltypes.Value) ([]byte, error) {
 		}
 	case sqltypes.Decimal, sqltypes.Text, sqltypes.Blob, sqltypes.VarChar,
 		sqltypes.VarBinary, sqltypes.Char, sqltypes.Bit, sqltypes.Enum,
-		sqltypes.Set, sqltypes.Geometry, sqltypes.Binary, sqltypes.TypeJSON:
+		sqltypes.Set, sqltypes.Geometry, sqltypes.Binary, sqltypes.TypeJSON, sqltypes.Vector:
 		l := len(v.Raw())
 		length := lenEncIntSize(uint64(l)) + l
 		out = make([]byte, length)
@@ -1598,7 +1598,7 @@ func val2MySQLLen(v sqltypes.Value) (int, error) {
 		}
 	case sqltypes.Decimal, sqltypes.Text, sqltypes.Blob, sqltypes.VarChar,
 		sqltypes.VarBinary, sqltypes.Char, sqltypes.Bit, sqltypes.Enum,
-		sqltypes.Set, sqltypes.Geometry, sqltypes.Binary, sqltypes.TypeJSON:
+		sqltypes.Set, sqltypes.Geometry, sqltypes.Binary, sqltypes.TypeJSON, sqltypes.Vector:
 		l := len(v.Raw())
 		length = lenEncIntSize(uint64(l)) + l
 	default:


### PR DESCRIPTION
GMS uses Vitess code to encode responses into the MySQL wire format.

Testing for this change is in the corresponding GMS PR.