### PR TITLE
[no-release-notes] add CreateViewStr constant alongside other Create*Str constants

### DIFF
--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -4062,6 +4062,7 @@ const (
 	CreateProcedureStr = "create procedure"
 	CreateEventStr     = "create event"
 	CreateTableStr     = "create table"
+	CreateViewStr      = "create view"
 
 	ProcedureStatusStr = "procedure status"
 	FunctionStatusStr  = "function status"


### PR DESCRIPTION
Blocks dolthub/go-mysql-server#3516