### PR TITLE
Relax error handling for `COM_FIELD_LIST` to avoid mysql client disconnecting

### DIFF
--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -62,7 +62,7 @@ const (
 	ephemeralRead
 )
 
-// SingleStringElementFormatString is a template string that formats a single string element. 
+// SingleStringElementFormatString is a template string that formats a single string element.
 const SingleStringElementFormatString = "%s"
 
 // A Getter has a Get()
@@ -1029,13 +1029,7 @@ func (c *Conn) handleNextCommand(ctx context.Context, handler Handler) error {
 
 		sql := fmt.Sprintf("SELECT * FROM %s LIMIT 0;", formatID(table))
 		err = handler.ComQuery(ctx, c, sql, func(qr *sqltypes.Result, more bool) error {
-			// only send meta data, no rows
-			if len(qr.Fields) == 0 {
-				return NewSQLErrorFromError(errors.New("unexpected: query ended without fields and no error"))
-			}
-
 			// for COM_FIELD_LIST response, don't send the number of fields first.
-
 			for _, field := range qr.Fields {
 				if err := c.writeColumnDefinition(field, true); err != nil {
 					return err
@@ -1045,11 +1039,7 @@ func (c *Conn) handleNextCommand(ctx context.Context, handler Handler) error {
 		})
 
 		if err != nil {
-			if werr := c.writeErrorPacketFromError(err); werr != nil {
-				// If we can't even write the error, we're done.
-				log.Errorf("Error writing query error to %s: %v", c, werr)
-				return werr
-			}
+			log.Warningf("COM_FIELD_LIST query error for table %s: %v", table, err)
 		}
 		if err := c.writeEndResult(false, 0, 0, handler.WarningCount(c)); err != nil {
 			log.Errorf("Error writing result to %s: %v", c, err)


### PR DESCRIPTION
The mysql client sends `COM_FIELD_LIST` commands by default (unless the `-A` option is given) to collect field metadata for all tables/views. If a view has a broken definition, then it was returning an error, which caused the mysql client to disconnect and reconnect. This change ignores errors when querying tables/views for a `COM_FIELD_LIST` command, which fixes the client disconnect issue and lets us match the MySQL server's behavior. 

GMS CI Tests: https://github.com/dolthub/go-mysql-server/pull/3518
Dolt CI Tests: https://github.com/dolthub/dolt/pull/10912

Fixes https://github.com/dolthub/dolt/issues/10634