### PR TITLE
go/mysql: add Conn.WaitForClientActivity to detect a departed client

### DIFF
--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -163,6 +163,12 @@ type Conn struct {
 	bufferedWriter *bufio.Writer
 	sequence       uint8
 
+	// readLease coordinates exclusive ownership of the read side between the
+	// optional client-activity watcher (WaitForClientActivity) and
+	// handler-initiated reads that consume client->server packets mid-query
+	// (LoadInfile / HandleLoadDataLocalQuery for LOAD DATA LOCAL INFILE).
+	readLease readLease
+
 	// fields contains the fields definitions for an on-going
 	// streaming query. It is set by ExecuteStreamFetch, and
 	// cleared by the last FetchNext().  It is nil if no streaming
@@ -239,11 +245,13 @@ var writersPool = sync.Pool{New: func() interface{} { return bufio.NewWriterSize
 // newConn is an internal method to create a Conn. Used by client and server
 // side for common creation code.
 func newConn(conn net.Conn) *Conn {
-	return &Conn{
+	c := &Conn{
 		Conn:           conn,
 		closed:         sync2.NewAtomicBool(false),
 		bufferedReader: bufio.NewReaderSize(conn, DefaultConnBufferSize),
 	}
+	c.readLease.interrupt = func() { _ = c.Conn.SetReadDeadline(aLongTimeAgo) }
+	return c
 }
 
 // newServerConn should be used to create server connections.
@@ -261,6 +269,7 @@ func newServerConn(conn net.Conn, listener *Listener) *Conn {
 	if listener.connReadBufferSize > 0 {
 		c.bufferedReader = bufio.NewReaderSize(conn, listener.connReadBufferSize)
 	}
+	c.readLease.interrupt = func() { _ = c.Conn.SetReadDeadline(aLongTimeAgo) }
 	return c
 }
 
@@ -324,6 +333,234 @@ func (c *Conn) getReader() io.Reader {
 		return c.bufferedReader
 	}
 	return c.Conn
+}
+
+// aLongTimeAgo is a deadline far enough in the past to immediately interrupt a
+// blocked Read when set as the connection's read deadline.
+var aLongTimeAgo = time.Unix(1, 0)
+
+// ErrClientWroteWhileBusy is returned by WaitForClientActivity when the client
+// sends data while the server is executing a query and is not expecting any
+// input. The MySQL protocol is half-duplex with no pipelining: the client must
+// fully consume the current result before issuing another command, so any such
+// data means the client is no longer waiting for the in-flight query's result
+// (for example, a COM_QUIT sent while the query is still running).
+var ErrClientWroteWhileBusy = errors.New("client wrote to connection while a query was executing")
+
+// readLease coordinates exclusive ownership of a Conn's read side between the
+// optional client-activity watcher (WaitForClientActivity) and handler-initiated
+// reads that consume client->server packets in the middle of a query (currently
+// LoadInfile / HandleLoadDataLocalQuery for LOAD DATA LOCAL INFILE).
+//
+// The MySQL protocol is half-duplex with no pipelining, so during query
+// execution the read side is normally idle and the watcher can sit in a blocking
+// Peek to notice a client that has gone away. LOAD DATA LOCAL INFILE is the
+// exception: the server asks the client to stream a file back mid-COM_QUERY, so
+// the handler must read those packets off the same connection. The watcher and
+// that read must never touch the bufio.Reader concurrently.
+//
+// A handler read calls acquire() before reading from the client and release()
+// once the exchange has been fully drained and the protocol is quiescent again.
+// acquire() preempts a parked watcher and blocks until the watcher has confirmed
+// it has left its Peek, so the handoff is race-free; the watcher does not consume
+// the byte it peeks, so nothing the handler needs is lost. While the lease is
+// held the watcher stays suspended and only resumes watching after release().
+type readLease struct {
+	mu sync.Mutex
+	// held is true while a handler-initiated read owns the read side.
+	held bool
+	// freeCh is created by acquire() and closed by release(); anyone waiting for
+	// the lease to become free selects on it.
+	freeCh chan struct{}
+	// preempt is non-nil while a watcher is parked in Peek. acquire() closes it
+	// to ask the watcher to relinquish the read side, then sets it to nil.
+	preempt chan struct{}
+	// yielded is closed by the watcher once it has exited its Peek in response to
+	// a preempt, telling acquire() the handoff is complete.
+	yielded chan struct{}
+	// interrupt wakes a watcher parked in Peek by setting a read deadline in the
+	// past. It is installed once at connection construction (to
+	// c.Conn.SetReadDeadline(aLongTimeAgo)) and called by acquire() under mu when
+	// it preempts a parked watcher. Calling it under mu orders the interrupt
+	// before the watcher's deadline reset, which the watcher performs only after
+	// re-acquiring mu (see WaitForClientActivity).
+	interrupt func()
+}
+
+// acquire takes exclusive ownership of the read side for a handler-initiated
+// read, preempting and suspending any active client-activity watcher. It blocks
+// until a parked watcher has relinquished the read side, so the caller may read
+// without racing it. Every acquire must be paired with exactly one release.
+func (l *readLease) acquire() {
+	l.mu.Lock()
+	for l.held {
+		// Another handler read owns the read side; wait for it to finish.
+		fc := l.freeCh
+		l.mu.Unlock()
+		<-fc
+		l.mu.Lock()
+	}
+	l.held = true
+	l.freeCh = make(chan struct{})
+	var ack chan struct{}
+	if l.preempt != nil {
+		// A watcher is parked in Peek. Wake it by setting a past read deadline,
+		// mark it preempted (close preempt so the watcher sees preempt == nil), and
+		// remember the channel it will close once it has actually left the Peek.
+		// interrupt() runs under mu so it is ordered before the watcher's deadline
+		// reset, which happens only after the watcher re-acquires mu below.
+		ack = l.yielded
+		l.interrupt()
+		close(l.preempt)
+		l.preempt = nil
+	}
+	l.mu.Unlock()
+	if ack != nil {
+		<-ack
+	}
+}
+
+// release relinquishes the read side acquired by acquire, allowing a suspended
+// watcher to resume watching.
+func (l *readLease) release() {
+	l.mu.Lock()
+	l.held = false
+	if l.freeCh != nil {
+		close(l.freeCh)
+		l.freeCh = nil
+	}
+	l.mu.Unlock()
+}
+
+// WaitForClientActivity blocks until the client connection becomes readable
+// (the client sent data or closed its end), or until ctx is cancelled. It is
+// meant to be used by the server while a query is executing, to detect a client
+// that has gone away: the protocol is half-duplex with no pipelining, so no
+// client->server bytes are expected between sending a command and receiving its
+// full result.
+//
+// It returns:
+//   - nil if ctx is cancelled first. This is the normal "the query finished,
+//     stop watching" path.
+//   - a non-nil error if the client closed the connection (e.g. io.EOF or a
+//     connection reset) or sent data unexpectedly (ErrClientWroteWhileBusy).
+//
+// The caller should treat any non-nil return as "the client is no longer
+// waiting for this result" and cancel the in-flight query.
+//
+// LOAD DATA LOCAL INFILE is a documented exception to the "no client->server
+// bytes mid-query" rule: the handler itself reads the streamed file off the
+// connection. Those reads go through LoadInfile / HandleLoadDataLocalQuery, which
+// take the connection's read lease; this function honors that lease, suspending
+// the watch for the duration of the handler read rather than racing it or
+// mistaking the file bytes for a disconnect.
+//
+// WaitForClientActivity does not consume any bytes: if the client did send
+// data, it remains buffered for the next command read. It must only be called
+// when no other goroutine is reading from the connection (apart from a
+// lease-holding handler read, which it coordinates with), and the caller must
+// ensure it has returned before resuming normal command reads (e.g. by
+// cancelling ctx and joining the goroutine it runs in). If the connection has
+// no read buffer (ConnReadBufferSize == 0) it cannot peek without consuming a
+// byte the command loop needs, so it returns nil immediately.
+func (c *Conn) WaitForClientActivity(ctx context.Context) error {
+	if c.bufferedReader == nil {
+		return nil
+	}
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil
+		}
+
+		// Wait until no handler-initiated read owns the read side, then register
+		// ourselves as the parked watcher so such a read can preempt us. Both the
+		// check and the registration happen under the lease mutex, so there is no
+		// window in which we begin peeking while a handler read is in progress.
+		preempt := make(chan struct{})
+		yielded := make(chan struct{})
+		c.readLease.mu.Lock()
+		if c.readLease.held {
+			fc := c.readLease.freeCh
+			c.readLease.mu.Unlock()
+			select {
+			case <-fc:
+			case <-ctx.Done():
+				return nil
+			}
+			continue
+		}
+		c.readLease.preempt = preempt
+		c.readLease.yielded = yielded
+		c.readLease.mu.Unlock()
+
+		// Translate ctx cancellation into an interrupted read by setting a read
+		// deadline in the past, which wakes the blocked Peek below. A lease
+		// preemption is handled separately: acquire() sets the same past deadline
+		// directly (via c.readLease.interrupt) under the lease mutex.
+		//
+		// context.AfterFunc runs the callback only if ctx is cancelled, so the
+		// common path where Peek returns on its own (a client disconnect or an
+		// unexpected client write) spawns no goroutine. afFired is closed by the
+		// callback once it has set the deadline; we join on it before resetting the
+		// deadline so a stale past deadline cannot survive the reset.
+		//
+		// A single SetReadDeadline(aLongTimeAgo) is sufficient even when the
+		// connection is wrapped in netutil.ConnWithTimeouts (which re-arms a
+		// managed read deadline on every Read): SetReadDeadline there is a
+		// single-shot override that the next Read honors instead of re-arming, so
+		// the interrupt cannot be lost to a re-arm that races our set. The reset
+		// to the zero time below restores the managed timeout for subsequent
+		// reads.
+		afFired := make(chan struct{})
+		stopAfter := context.AfterFunc(ctx, func() {
+			_ = c.Conn.SetReadDeadline(aLongTimeAgo)
+			close(afFired)
+		})
+
+		_, err := c.bufferedReader.Peek(1)
+
+		// Deregister the ctx callback. If it had already started running, wait for
+		// it to finish setting the deadline so our reset below cannot be undone.
+		if !stopAfter() {
+			<-afFired
+		}
+
+		// Unregister and detect whether a handler read preempted us. Only
+		// acquire() sets preempt to nil, so a nil here means we were preempted.
+		// Re-acquiring the lease mutex here also orders any preempt interrupt
+		// (issued by acquire under the same mutex) before the deadline reset below.
+		c.readLease.mu.Lock()
+		preempted := c.readLease.preempt == nil
+		c.readLease.preempt = nil
+		c.readLease.yielded = nil
+		c.readLease.mu.Unlock()
+
+		// Reset the deadline only after both wake sources have settled: the ctx
+		// callback has been joined (afFired) and any preempt interrupt is ordered
+		// before our re-acquisition of the lease mutex above.
+		_ = c.Conn.SetReadDeadline(time.Time{})
+
+		if preempted {
+			// A handler read (e.g. LoadInfile) preempted us. Acknowledge that we
+			// have left the Peek so it may proceed, then loop to wait for it to
+			// finish before watching again. The byte we peeked, if any, was not
+			// consumed and remains buffered for the handler read.
+			close(yielded)
+			continue
+		}
+
+		// If we were asked to stop, ignore whatever the Peek observed: it may
+		// have been our own past deadline, or a real disconnect that raced with
+		// the cancellation. Either way the caller is no longer interested.
+		if ctx.Err() != nil {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		return ErrClientWroteWhileBusy
+	}
 }
 
 func (c *Conn) readHeaderFrom(ctx context.Context, r io.Reader) (int, error) {
@@ -821,13 +1058,22 @@ func (c *Conn) writeLoadInfilePacket(fileName string) error {
 // method will block while the remainder of the file contents are read from the
 // client and discarded.
 func (c *Conn) LoadInfile(file string) (io.ReadCloser, error) {
+	// Take exclusive ownership of the read side so we do not race a
+	// client-activity watcher (WaitForClientActivity) while we read the file the
+	// client streams back. The lease is released once the whole exchange has been
+	// drained and the protocol is quiescent again (in the reader goroutine
+	// below), at which point a suspended watcher may resume.
+	c.readLease.acquire()
+
 	err := c.writeLoadInfilePacket(file)
 	if err != nil {
+		c.readLease.release()
 		return nil, err
 	}
 
 	err = c.flush(context.Background())
 	if err != nil {
+		c.readLease.release()
 		return nil, err
 	}
 
@@ -836,6 +1082,7 @@ func (c *Conn) LoadInfile(file string) (io.ReadCloser, error) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+		defer c.readLease.release()
 		// Read contents from client response, write it to |writer|.
 		data, err := c.readEphemeralPacket(context.Background())
 		if err != nil {
@@ -885,6 +1132,12 @@ func (r *finalizingReader) Close() error {
 }
 
 func (c *Conn) HandleLoadDataLocalQuery(tmpdir string, tmpfileName string, file string) error {
+	// Take exclusive ownership of the read side so we do not race a
+	// client-activity watcher (WaitForClientActivity) while we read the file the
+	// client streams back; released once the whole exchange is drained.
+	c.readLease.acquire()
+	defer c.readLease.release()
+
 	// First send the load infile packet and flush the connector
 	err := c.writeLoadInfilePacket(file)
 	if err != nil {

--- a/go/mysql/conn_test.go
+++ b/go/mysql/conn_test.go
@@ -20,6 +20,8 @@ import (
 	"bytes"
 	"context"
 	crypto_rand "crypto/rand"
+	"errors"
+	"io"
 	"math/rand"
 	"net"
 	"reflect"
@@ -282,5 +284,363 @@ func TestEOFOrLengthEncodedIntFuzz(t *testing.T) {
 		if (isInt && isEOF) || (!isInt && !isEOF) {
 			t.Fatalf("0xfe bytestring is EOF xor Int. Bytes %v", bytes)
 		}
+	}
+}
+
+// waitForActivity runs sConn.WaitForClientActivity in a goroutine and returns
+// its error, failing the test if it doesn't return within a generous timeout.
+func waitForActivity(t *testing.T, sConn *Conn, ctx context.Context) error {
+	t.Helper()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- sConn.WaitForClientActivity(ctx)
+	}()
+	select {
+	case err := <-errCh:
+		return err
+	case <-time.After(5 * time.Second):
+		t.Fatal("WaitForClientActivity did not return in time")
+		return nil
+	}
+}
+
+// TestWaitForClientActivityCancel verifies that cancelling the context unblocks
+// the watch with a nil error and leaves the connection usable for a subsequent
+// read.
+func TestWaitForClientActivityCancel(t *testing.T) {
+	listener, sConn, cConn := createSocketPair(t)
+	defer listener.Close()
+	defer sConn.Close()
+	defer cConn.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- sConn.WaitForClientActivity(ctx)
+	}()
+
+	// Give the watch time to block in Peek, then cancel it.
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("expected nil after cancel, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("WaitForClientActivity did not return after cancel")
+	}
+
+	// The connection must still be usable: the deadline we set to interrupt the
+	// peek must have been cleared.
+	if _, err := cConn.Conn.Write([]byte{0x42}); err != nil {
+		t.Fatalf("client write failed: %v", err)
+	}
+	b, err := sConn.bufferedReader.ReadByte()
+	if err != nil {
+		t.Fatalf("server read after cancel failed: %v", err)
+	}
+	if b != 0x42 {
+		t.Fatalf("expected 0x42, got 0x%x", b)
+	}
+}
+
+// TestWaitForClientActivityClosed verifies that a client disconnect unblocks the
+// watch with a non-nil error.
+func TestWaitForClientActivityClosed(t *testing.T) {
+	listener, sConn, cConn := createSocketPair(t)
+	defer listener.Close()
+	defer sConn.Close()
+
+	// Close the client end while the server is watching.
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cConn.Close()
+	}()
+
+	err := waitForActivity(t, sConn, context.Background())
+	if err == nil {
+		t.Fatal("expected non-nil error when client closed, got nil")
+	}
+	if errors.Is(err, ErrClientWroteWhileBusy) {
+		t.Fatalf("expected a disconnect error, got ErrClientWroteWhileBusy")
+	}
+	// On a clean close the peer-side read observes io.EOF.
+	if !errors.Is(err, io.EOF) {
+		t.Logf("client-close error was %v (not io.EOF); acceptable if it's a reset", err)
+	}
+}
+
+// TestWaitForClientActivityUnexpectedData verifies that data sent by the client
+// while a query is "executing" is reported as ErrClientWroteWhileBusy and is not
+// consumed (it remains available for the next command read).
+func TestWaitForClientActivityUnexpectedData(t *testing.T) {
+	listener, sConn, cConn := createSocketPair(t)
+	defer listener.Close()
+	defer sConn.Close()
+	defer cConn.Close()
+
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cConn.Conn.Write([]byte{0x07, 0x08, 0x09})
+	}()
+
+	err := waitForActivity(t, sConn, context.Background())
+	if !errors.Is(err, ErrClientWroteWhileBusy) {
+		t.Fatalf("expected ErrClientWroteWhileBusy, got %v", err)
+	}
+
+	// The bytes must not have been consumed by the watch.
+	want := []byte{0x07, 0x08, 0x09}
+	for i, w := range want {
+		b, err := sConn.bufferedReader.ReadByte()
+		if err != nil {
+			t.Fatalf("reading byte %d after watch failed: %v", i, err)
+		}
+		if b != w {
+			t.Fatalf("byte %d: expected 0x%x, got 0x%x", i, w, b)
+		}
+	}
+}
+
+// TestWaitForClientActivityYieldsToHandlerRead verifies that a handler-initiated
+// read (modeled here by taking the read lease, as LoadInfile does) preempts and
+// suspends an active watcher: the watcher must not race the read, must not treat
+// the bytes the client sends during the lease as a disconnect, and must resume
+// watching once the lease is released. This is the LOAD DATA LOCAL INFILE case.
+func TestWaitForClientActivityYieldsToHandlerRead(t *testing.T) {
+	listener, sConn, cConn := createSocketPair(t)
+	defer listener.Close()
+	defer sConn.Close()
+	defer cConn.Close()
+
+	// Start the watcher and let it park in Peek.
+	watchCtx, cancelWatch := context.WithCancel(context.Background())
+	watchErr := make(chan error, 1)
+	go func() { watchErr <- sConn.WaitForClientActivity(watchCtx) }()
+	time.Sleep(100 * time.Millisecond)
+
+	// A handler read takes the read lease, preempting the parked watcher. acquire
+	// must block until the watcher has left its Peek, so we own the read side.
+	sConn.readLease.acquire()
+
+	// The watcher must not have returned: it was preempted, not triggered.
+	select {
+	case err := <-watchErr:
+		t.Fatalf("watcher returned when preempted by a handler read: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// While we hold the lease, the client sends bytes (as a LOAD DATA client
+	// streams a file). The suspended watcher must neither consume these nor
+	// report them as activity; the handler read owns them.
+	want := []byte{0x41, 0x42, 0x43, 0x44}
+	if _, err := cConn.Conn.Write(want); err != nil {
+		t.Fatalf("client write failed: %v", err)
+	}
+	got := make([]byte, len(want))
+	if _, err := io.ReadFull(sConn.bufferedReader, got); err != nil {
+		t.Fatalf("handler read failed: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("handler read got %v, want %v", got, want)
+	}
+
+	// Still no false trigger while suspended.
+	select {
+	case err := <-watchErr:
+		t.Fatalf("watcher returned while lease held: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Release the lease; the watcher resumes watching the now-idle connection.
+	sConn.readLease.release()
+
+	// Cancelling returns nil and leaves the connection usable, proving the
+	// watcher cleanly resumed and re-armed its deadline handling.
+	cancelWatch()
+	select {
+	case err := <-watchErr:
+		if err != nil {
+			t.Fatalf("expected nil after cancel, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("watcher did not return after cancel")
+	}
+}
+
+// rearmingConn models netutil.ConnWithTimeouts for tests: at the start of every
+// Read it re-arms a long managed read deadline, UNLESS an explicit deadline was
+// set via SetReadDeadline (a single-shot override that the next Read honors
+// instead of re-arming, then clears). It gates the per-Read decision on
+// allowRearm and announces Read entry on readEntered, so a test can determin-
+// istically force the ordering where the watcher's interrupt deadline is set
+// before the Read makes its re-arm-vs-override decision.
+type rearmingConn struct {
+	net.Conn
+	timeout     time.Duration
+	mu          sync.Mutex
+	override    bool
+	readOnce    sync.Once
+	readEntered chan struct{}
+	allowRearm  chan struct{}
+}
+
+func (c *rearmingConn) SetReadDeadline(t time.Time) error {
+	c.mu.Lock()
+	c.override = !t.IsZero()
+	c.mu.Unlock()
+	return c.Conn.SetReadDeadline(t)
+}
+
+func (c *rearmingConn) Read(b []byte) (int, error) {
+	c.readOnce.Do(func() { close(c.readEntered) })
+	// Gate before the re-arm/override decision so a test can set an explicit
+	// deadline in the window before this Read decides whether to re-arm.
+	<-c.allowRearm
+	c.mu.Lock()
+	override := c.override
+	c.override = false
+	c.mu.Unlock()
+	if !override {
+		_ = c.Conn.SetReadDeadline(time.Now().Add(c.timeout))
+	}
+	return c.Conn.Read(b)
+}
+
+// TestWaitForClientActivityWakesThroughRearmingConn is a regression test for a
+// deadlock: a connection that re-arms a long managed read deadline on every Read
+// (netutil.ConnWithTimeouts with net_read_timeout) could, if its SetReadDeadline
+// were overwritten by that re-arm, leave the watcher's Peek blocked for the whole
+// managed timeout and hang the query-done join. With the single-shot override
+// contract, the interrupt deadline the watcher sets before the Read's decision is
+// honored (the Read skips the re-arm) and the Peek wakes. This drives that exact
+// ordering and asserts the watcher returns promptly.
+func TestWaitForClientActivityWakesThroughRearmingConn(t *testing.T) {
+	listener, sConn, cConn := createSocketPair(t)
+	defer listener.Close()
+	defer cConn.Close()
+
+	// Rebuild the server Conn on top of a connection that re-arms a very long
+	// managed read deadline but honors single-shot overrides, like ConnWithTimeouts.
+	rc := &rearmingConn{
+		Conn:        sConn.Conn,
+		timeout:     time.Hour,
+		readEntered: make(chan struct{}),
+		allowRearm:  make(chan struct{}),
+	}
+	sConn = newConn(rc)
+	defer sConn.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	watchErr := make(chan error, 1)
+	go func() { watchErr <- sConn.WaitForClientActivity(ctx) }()
+
+	// Wait until the watcher's Peek has entered Read but is gated before its
+	// re-arm/override decision.
+	select {
+	case <-rc.readEntered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("watcher never reached Read")
+	}
+
+	// Cancel now, while the decision is still gated, so the watcher's interrupt
+	// deadline (and the single-shot override it sets) lands before the re-arm.
+	cancel()
+	time.Sleep(50 * time.Millisecond)
+
+	// Release the gate. With the single-shot override honored, the Read skips the
+	// hour-long re-arm and reads under the past interrupt deadline, waking at once.
+	close(rc.allowRearm)
+
+	select {
+	case err := <-watchErr:
+		if err != nil {
+			t.Fatalf("expected nil after cancel, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("watcher hung: interrupt deadline was lost to the connection's re-arm")
+	}
+}
+
+// TestLoadInfileWithActiveWatcher is an end-to-end check of LOAD DATA LOCAL
+// INFILE while the connection watcher is running: the server reads a file the
+// client streams back mid-query via LoadInfile. The watcher must suspend for the
+// duration of the transfer (via the read lease) rather than racing the read or
+// mistaking the file bytes for a client disconnect, and the file contents must
+// arrive intact.
+func TestLoadInfileWithActiveWatcher(t *testing.T) {
+	listener, sConn, cConn := createSocketPair(t)
+	defer listener.Close()
+	defer sConn.Close()
+	defer cConn.Close()
+
+	// LoadInfile begins a fresh packet exchange; align both sequence numbers.
+	sConn.sequence = 0
+	cConn.sequence = 0
+
+	// Start the watcher and let it park in Peek.
+	watchCtx, cancelWatch := context.WithCancel(context.Background())
+	watchErr := make(chan error, 1)
+	go func() { watchErr <- sConn.WaitForClientActivity(watchCtx) }()
+	time.Sleep(100 * time.Millisecond)
+
+	// Cooperating client: answer the load-infile request with the file contents
+	// followed by a terminating empty packet.
+	const fileContents = "hello, world\nsecond line\n"
+	clientDone := make(chan error, 1)
+	go func() {
+		ctx := context.Background()
+		if _, err := cConn.ReadPacket(ctx); err != nil {
+			clientDone <- err
+			return
+		}
+		if err := cConn.writePacket([]byte(fileContents)); err != nil {
+			clientDone <- err
+			return
+		}
+		if err := cConn.writePacket([]byte{}); err != nil {
+			clientDone <- err
+			return
+		}
+		clientDone <- cConn.flush(ctx)
+	}()
+
+	// Server side: LoadInfile preempts the watcher via the read lease.
+	reader, err := sConn.LoadInfile("does-not-matter.txt")
+	if err != nil {
+		t.Fatalf("LoadInfile failed: %v", err)
+	}
+	got, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("reading infile contents failed: %v", err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatalf("closing infile reader failed: %v", err)
+	}
+	if string(got) != fileContents {
+		t.Fatalf("infile contents corrupted:\n got %q\nwant %q", got, fileContents)
+	}
+	if err := <-clientDone; err != nil {
+		t.Fatalf("client cooperator failed: %v", err)
+	}
+
+	// The watcher must not have fired during the transfer.
+	select {
+	case err := <-watchErr:
+		t.Fatalf("watcher returned during LOAD DATA (false disconnect): %v", err)
+	default:
+	}
+
+	// The watcher resumed after the transfer; cancelling returns nil.
+	cancelWatch()
+	select {
+	case err := <-watchErr:
+		if err != nil {
+			t.Fatalf("expected nil after cancel, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("watcher did not return after cancel")
 	}
 }

--- a/go/netutil/conn.go
+++ b/go/netutil/conn.go
@@ -26,26 +26,47 @@ type ConnWithTimeouts struct {
 	net.Conn
 	readTimeout  time.Duration
 	writeTimeout time.Duration
-	mu           *sync.Mutex
+	// readOverride/writeOverride, when true, indicate that an explicit deadline
+	// has been set via Set{,Read,Write}Deadline and must be honored for exactly
+	// the next Read/Write instead of re-arming the managed timeout. They are
+	// cleared when that next operation consumes them, after which the managed
+	// timeout resumes.
+	readOverride  bool
+	writeOverride bool
+	mu            sync.Mutex
 }
 
-// NewConnWithTimeouts wraps a net.Conn with read and write timeouts.
-// It sets a new read or write deadline on every Read or Write call,
-// based on the given Deadline.
+// NewConnWithTimeouts wraps a net.Conn with managed read and write timeouts.
+// It re-arms a fresh read or write deadline (now + the configured duration) at
+// the start of every Read or Write, so each operation is bounded by that
+// duration. A zero duration disables the corresponding managed timeout.
 //
-// If a client calls Set{,Read,Write}Deadline on this connection,
-// the managed timeouts are disabled and the new deadlines are
-// forwarded to the underlying connection. It is assumed the client
-// is fully responsible for deadline handling from that point forward.
-func NewConnWithTimeouts(conn net.Conn, readTimeout time.Duration, writeTimeout time.Duration) ConnWithTimeouts {
-	return ConnWithTimeouts{Conn: conn, readTimeout: readTimeout, writeTimeout: writeTimeout, mu: &sync.Mutex{}}
+// Set{,Read,Write}Deadline with a non-zero time is a single-shot override: the
+// explicit deadline is forwarded to the underlying connection and applies to the
+// next Read/Write only (which skips the managed re-arm); the managed timeout then
+// resumes on the following operation. Set{,Read,Write}Deadline with the zero time
+// drops any pending override and resumes the managed timeout immediately. This
+// lets a caller transiently interrupt or extend a single operation (e.g. cancel a
+// blocked Read by setting a deadline in the past) without permanently disabling
+// the connection's managed timeout.
+//
+// The returned *ConnWithTimeouts is not safe to copy.
+func NewConnWithTimeouts(conn net.Conn, readTimeout time.Duration, writeTimeout time.Duration) *ConnWithTimeouts {
+	return &ConnWithTimeouts{Conn: conn, readTimeout: readTimeout, writeTimeout: writeTimeout}
 }
 
 // Implementation of the Conn interface.
 
-// Read sets a read deadilne and delegates to conn.Read.
-func (c ConnWithTimeouts) Read(b []byte) (int, error) {
+// Read sets a read deadline and delegates to conn.Read.
+func (c *ConnWithTimeouts) Read(b []byte) (int, error) {
 	c.mu.Lock()
+	if c.readOverride {
+		// An explicit deadline was set for this read; honor it once, then let
+		// the managed timeout resume on the next read.
+		c.readOverride = false
+		c.mu.Unlock()
+		return c.Conn.Read(b)
+	}
 	if c.readTimeout == 0 {
 		c.mu.Unlock()
 		return c.Conn.Read(b)
@@ -59,8 +80,15 @@ func (c ConnWithTimeouts) Read(b []byte) (int, error) {
 }
 
 // Write sets a write deadline and delegates to conn.Write
-func (c ConnWithTimeouts) Write(b []byte) (int, error) {
+func (c *ConnWithTimeouts) Write(b []byte) (int, error) {
 	c.mu.Lock()
+	if c.writeOverride {
+		// An explicit deadline was set for this write; honor it once, then let
+		// the managed timeout resume on the next write.
+		c.writeOverride = false
+		c.mu.Unlock()
+		return c.Conn.Write(b)
+	}
 	if c.writeTimeout == 0 {
 		c.mu.Unlock()
 		return c.Conn.Write(b)
@@ -73,27 +101,30 @@ func (c ConnWithTimeouts) Write(b []byte) (int, error) {
 	return c.Conn.Write(b)
 }
 
-// SetDeadline implements the Conn SetDeadline method.
-func (c ConnWithTimeouts) SetDeadline(t time.Time) error {
+// SetDeadline implements the Conn SetDeadline method. See the type doc for the
+// single-shot override / zero-resumes-managed semantics.
+func (c *ConnWithTimeouts) SetDeadline(t time.Time) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.readTimeout = 0
-	c.writeTimeout = 0
+	c.readOverride = !t.IsZero()
+	c.writeOverride = !t.IsZero()
 	return c.Conn.SetDeadline(t)
 }
 
-// SetReadDeadline implements the Conn SetReadDeadline method.
-func (c ConnWithTimeouts) SetReadDeadline(t time.Time) error {
+// SetReadDeadline implements the Conn SetReadDeadline method. See the type doc
+// for the single-shot override / zero-resumes-managed semantics.
+func (c *ConnWithTimeouts) SetReadDeadline(t time.Time) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.readTimeout = 0
+	c.readOverride = !t.IsZero()
 	return c.Conn.SetReadDeadline(t)
 }
 
-// SetWriteDeadline implements the Conn SetWriteDeadline method.
-func (c ConnWithTimeouts) SetWriteDeadline(t time.Time) error {
+// SetWriteDeadline implements the Conn SetWriteDeadline method. See the type doc
+// for the single-shot override / zero-resumes-managed semantics.
+func (c *ConnWithTimeouts) SetWriteDeadline(t time.Time) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.writeTimeout = 0
+	c.writeOverride = !t.IsZero()
 	return c.Conn.SetWriteDeadline(t)
 }

--- a/go/netutil/conn_test.go
+++ b/go/netutil/conn_test.go
@@ -167,3 +167,74 @@ func TestNoTimeouts(t *testing.T) {
 		// NOOP
 	}
 }
+
+// TestSingleShotOverrideResumesManagedTimeout verifies the single-shot override
+// contract: SetReadDeadline with an explicit (non-zero) deadline applies to the
+// next Read only, which skips the managed re-arm; the managed timeout then
+// resumes on the following Read. This guards that a transient deadline override
+// (e.g. a watcher cancelling a blocked Read) does not permanently disable the
+// connection's managed timeout, so net_read_timeout still reaps afterward.
+func TestSingleShotOverrideResumesManagedTimeout(t *testing.T) {
+	listener, sConn, cConn := createSocketPair(t)
+	defer func() {
+		listener.Close()
+		sConn.Close()
+		cConn.Close()
+	}()
+
+	// Short managed read timeout; the peer never sends, so a managed Read times
+	// out quickly while an overridden Read with a far-future deadline does not.
+	const managed = 50 * time.Millisecond
+	s := NewConnWithTimeouts(sConn, managed, 0)
+
+	// Single-shot override: a far-future explicit deadline for the next Read.
+	if err := s.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		t.Fatalf("SetReadDeadline override failed: %v", err)
+	}
+	c := make(chan error, 1)
+	go func() {
+		_, err := s.Read(make([]byte, 10))
+		c <- err
+	}()
+
+	// The override must suppress the managed re-arm: the Read stays blocked well
+	// past the managed timeout.
+	select {
+	case err := <-c:
+		t.Fatalf("overridden Read returned (err=%v); managed timeout was not skipped", err)
+	case <-time.After(10 * managed):
+		// Good: still blocked under the far-future override.
+	}
+
+	// Wake the blocked Read with a past deadline, then resume managed timeouts.
+	if err := s.SetReadDeadline(time.Now().Add(-time.Hour)); err != nil {
+		t.Fatalf("SetReadDeadline (wake) failed: %v", err)
+	}
+	select {
+	case err := <-c:
+		if err == nil {
+			t.Fatalf("expected timeout error waking the overridden Read, got nil")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("overridden Read did not wake after past deadline")
+	}
+	// Zero time resumes the managed timeout (drops the override).
+	if err := s.SetReadDeadline(time.Time{}); err != nil {
+		t.Fatalf("SetReadDeadline(zero) failed: %v", err)
+	}
+
+	// The next Read must re-arm the managed timeout again (reaping resumed).
+	c2 := make(chan error, 1)
+	go func() {
+		_, err := s.Read(make([]byte, 10))
+		c2 <- err
+	}()
+	select {
+	case err := <-c2:
+		if err == nil || !strings.HasSuffix(err.Error(), "i/o timeout") {
+			t.Fatalf("expected managed i/o timeout after resume, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("managed timeout did not resume after a single-shot override")
+	}
+}


### PR DESCRIPTION
On context cancelation, the function returns with a `nil` error. If the client unexpectedly writes to the connection or closes it, then this method will return a non-`nil` error.

Unlike the first attempt at this method, this new implementation accounts for LoadDataInFile. It uses a preempt-able read lease to let the handler read from the client socket even while WaitForClientActivity is outstanding. The Peek becomes active once again after the reads are issued and completed.