### PR TITLE
go: sqlparser: Fix some panics on inputs with strange quotes, like SELECT''A.

### DIFF
--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -246,6 +246,11 @@ func adjustSubstatementPositions(sql string, tokenizer *Tokenizer) {
 }
 
 func trimQuotes(s string) string {
+	// A string shorter than two characters can't be quoted, and indexing into it below would panic.
+	if len(s) < 2 {
+		return s
+	}
+
 	firstChar := s[0]
 	lastChar := s[len(s)-1]
 	if firstChar == lastChar {
@@ -261,6 +266,10 @@ func trimQuotes(s string) string {
 }
 
 func stringIsUnbrokenQuote(s string, quoteChar byte) bool {
+	if len(s) < 2 {
+		return true
+	}
+
 	numConsecutiveQuotes := 0
 	numConsecutiveEscapes := 0
 	for _, c := range ([]byte)(s[1 : len(s)-1]) {

--- a/go/vt/sqlparser/ast_test.go
+++ b/go/vt/sqlparser/ast_test.go
@@ -1001,6 +1001,67 @@ func TestWindowErrors(t *testing.T) {
 	}
 }
 
+func TestTrimQuotes(t *testing.T) {
+	testcases := []struct {
+		input    string
+		expected string
+	}{
+		// Strings too short to be quoted are returned unmodified, rather than panicking.
+		{input: "", expected: ""},
+		{input: "'", expected: "'"},
+		{input: `"`, expected: `"`},
+		{input: "`", expected: "`"},
+		{input: "a", expected: "a"},
+		{input: "''", expected: ""},
+		{input: `""`, expected: ""},
+		{input: "``", expected: ""},
+		{input: "'a'", expected: "a"},
+		{input: `"a"`, expected: "a"},
+		{input: "`a`", expected: "a"},
+		{input: "'a", expected: "'a"},
+		{input: "a'", expected: "a'"},
+		{input: "aa", expected: "aa"},
+		// Quotes that don't span the whole string are left alone.
+		{input: `"1" + "2"`, expected: `"1" + "2"`},
+		{input: `'1' + '2'`, expected: `'1' + '2'`},
+		{input: `'it''s'`, expected: `it''s`},
+		{input: `'it\'s'`, expected: `it\'s`},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.expected, trimQuotes(tt.input))
+		})
+	}
+}
+
+// TestParseDegenerateQuotedExpressions asserts that queries with degenerate quoting in their select expressions
+// parse without panicking.
+func TestParseDegenerateQuotedExpressions(t *testing.T) {
+	testcases := []string{
+		"SELECT''A",
+		"SELECT''",
+		`SELECT""A`,
+		"SELECT``A",
+		"SELECT '' A",
+		"SELECT '' as A",
+		"SELECT ''A, ''B",
+		"SELECT (SELECT''A) B",
+		"SELECT''A FROM t WHERE x IN (SELECT''B FROM u)",
+		"INSERT INTO t SELECT''A",
+		"CREATE VIEW v AS SELECT''A",
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt, func(t *testing.T) {
+			require.NotPanics(t, func() {
+				// Some of these are valid and some aren't; all that matters is that we don't panic.
+				_, _ = Parse(tt)
+			})
+		})
+	}
+}
+
 func newStrVal(in string) *SQLVal {
 	return NewStrVal([]byte(in))
 }


### PR DESCRIPTION
In a context where sqlparser.Parse is called into without a recover(), this could cause a process crash and thus be an availability concern.

Thanks to Daniel Birtwhistle for the report.