### PR TITLE
Add conditional duplicate update metadata

### DIFF
--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -1740,17 +1740,20 @@ func (node *Stream) walkSubtree(visit Visit) error {
 // normal INSERT except if the row exists. In that case it first deletes
 // the row and re-inserts with new values. For that reason we keep it as an Insert struct.
 type Insert struct {
-	Auth       AuthInformation
-	Rows       InsertRows
-	With       *With
-	Table      TableName
-	Action     string
-	Ignore     string
-	Comments   Comments
-	Partitions Partitions
-	Columns    Columns
-	Returning  SelectExprs
-	OnDup      OnDup
+	Auth                           AuthInformation
+	Rows                           InsertRows
+	With                           *With
+	Table                          TableName
+	Action                         string
+	Ignore                         string
+	Comments                       Comments
+	Partitions                     Partitions
+	Columns                        Columns
+	Returning                      SelectExprs
+	OnDup                          OnDup
+	OnDupValuesAlias               string
+	OnDupWhere                     Expr
+	CountOnDuplicateUpdateAsOneRow bool
 }
 
 var _ AuthNode = (*Insert)(nil)
@@ -1770,6 +1773,9 @@ func (node *Insert) Format(buf *TrackedBuffer) {
 		buf.Myprintf(" partition (%v)", node.Partitions)
 	}
 	buf.Myprintf("%v %v%v", node.Columns, node.Rows, node.OnDup)
+	if node.OnDupWhere != nil {
+		buf.Myprintf(" where %v", node.OnDupWhere)
+	}
 	if len(node.Returning) > 0 {
 		buf.Myprintf(" returning %v", node.Returning)
 	}
@@ -1811,6 +1817,7 @@ func (node *Insert) walkSubtree(visit Visit) error {
 		node.Columns,
 		node.Rows,
 		node.OnDup,
+		node.OnDupWhere,
 		node.With,
 	)
 }

--- a/go/vt/sqlparser/ast_test.go
+++ b/go/vt/sqlparser/ast_test.go
@@ -113,6 +113,35 @@ func TestSelect(t *testing.T) {
 	}
 }
 
+func TestInsertOnDupWhereFormatAndWalk(t *testing.T) {
+	predicate := &ComparisonExpr{
+		Operator: LessThanStr,
+		Left:     NewColName("old_value"),
+		Right:    NewColName("new_value"),
+	}
+	insert := &Insert{
+		Action: InsertStr,
+		Table:  TableName{Name: NewTableIdent("t")},
+		Rows: &AliasedValues{Values: Values{
+			ValTuple{NewIntVal([]byte("1"))},
+		}},
+		OnDup: OnDup{
+			&AssignmentExpr{Name: NewColName("old_value"), Expr: NewIntVal([]byte("2"))},
+		},
+		OnDupWhere: predicate,
+	}
+
+	require.Equal(t, "insert into t values (1) on duplicate key update old_value = 2 where old_value < new_value", String(insert))
+	visitedPredicate := false
+	require.NoError(t, Walk(func(node SQLNode) (bool, error) {
+		if node == predicate {
+			visitedPredicate = true
+		}
+		return true, nil
+	}, insert))
+	require.True(t, visitedPredicate)
+}
+
 func TestRemoveHints(t *testing.T) {
 	for _, query := range []string{
 		"select * from t use index (i)",


### PR DESCRIPTION
Add insert AST metadata for a duplicate-update predicate and single-row affected-count semantics. This lets PostgreSQL dialect translation carry `ON CONFLICT DO UPDATE ... WHERE` behavior through the shared parser boundary.

Adds formatting and AST-walk coverage for the predicate.

Supports [dolthub/doltgresql#3235](https://github.com/dolthub/doltgresql/issues/3235).