### PR TITLE
Validate interval expression placement during parsing

### DIFF
--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -164,6 +164,7 @@ func ParseOneWithOptions(ctx context.Context, sql string, options ParserOptions)
 }
 
 func parseTokenizer(sql string, tokenizer *Tokenizer) (Statement, error) {
+	tokenizer.intervalExprs = nil
 	if yyParsePooled(tokenizer) != 0 {
 		if se, ok := tokenizer.LastError.(vterrors.SyntaxError); ok {
 			return nil, vterrors.NewWithCause(vtrpcpb.Code_INVALID_ARGUMENT, tokenizer.LastError.Error(), se)
@@ -174,9 +175,66 @@ func parseTokenizer(sql string, tokenizer *Tokenizer) (Statement, error) {
 	if tokenizer.ParseTree == nil {
 		return nil, ErrEmpty
 	}
+	if tokenizer.hasInvalidIntervalExpr() {
+		return nil, invalidIntervalSyntaxError(sql, tokenizer.Position)
+	}
 	captureSelectExpressions(sql, tokenizer)
 	adjustSubstatementPositions(sql, tokenizer)
 	return tokenizer.ParseTree, nil
+}
+
+// invalidIntervalSyntaxError returns the parser error used for unsupported interval positions.
+func invalidIntervalSyntaxError(sql string, position int) error {
+	err := vterrors.SyntaxError{Message: "syntax error", Position: position, Statement: sql}
+	return vterrors.NewWithCause(vtrpcpb.Code_INVALID_ARGUMENT, err.Error(), err)
+}
+
+// newIntervalExpr creates an interval and registers it for syntax validation.
+func newIntervalExpr(yylex interface{}, expr Expr, unit string) *IntervalExpr {
+	interval := &IntervalExpr{Expr: expr, Unit: unit}
+	if tokenizer, ok := yylex.(*Tokenizer); ok {
+		tokenizer.registerIntervalExpr(interval)
+	}
+	return interval
+}
+
+// newArithmeticExpr creates an arithmetic expression and permits intervals in MySQL's supported positions.
+func newArithmeticExpr(yylex interface{}, left Expr, operator string, right Expr) *BinaryExpr {
+	tokenizer, ok := yylex.(*Tokenizer)
+	if !ok {
+		return &BinaryExpr{Left: left, Operator: operator, Right: right}
+	}
+	_, leftIsInterval := left.(*IntervalExpr)
+	_, rightIsInterval := right.(*IntervalExpr)
+	if leftIsInterval && rightIsInterval {
+		return &BinaryExpr{Left: left, Operator: operator, Right: right}
+	}
+	if operator == PlusStr {
+		tokenizer.allowIntervalExpr(left)
+	}
+	tokenizer.allowIntervalExpr(right)
+	return &BinaryExpr{Left: left, Operator: operator, Right: right}
+}
+
+// newGenericFunctionExpr creates a function and permits MySQL date-function interval arguments.
+func newGenericFunctionExpr(yylex interface{}, qualifier TableIdent, name ColIdent, distinct bool, exprs SelectExprs) *FuncExpr {
+	function := &FuncExpr{Qualifier: qualifier, Name: name, Distinct: distinct, Exprs: exprs}
+	if !function.Qualifier.IsEmpty() || function.Distinct || len(function.Exprs) != 2 {
+		return function
+	}
+	switch function.Name.Lowered() {
+	case "adddate", "date_add", "date_sub", "subdate":
+	default:
+		return function
+	}
+	argument, ok := function.Exprs[1].(*AliasedExpr)
+	if !ok {
+		return function
+	}
+	if tokenizer, ok := yylex.(*Tokenizer); ok {
+		tokenizer.allowIntervalExpr(argument.Expr)
+	}
+	return function
 }
 
 // For select statements, capture the verbatim select expressions from the original query text.
@@ -312,6 +370,10 @@ func ParseNext(tokenizer *Tokenizer) (Statement, error) {
 	}
 	if tokenizer.ParseTree == nil {
 		return ParseNext(tokenizer)
+	}
+	if tokenizer.hasInvalidIntervalExpr() {
+		tokenizer.Error("syntax error")
+		return nil, tokenizer.LastError
 	}
 
 	captureSelectExpressions((string)(tokenizer.queryBuf), tokenizer)

--- a/go/vt/sqlparser/ast_test.go
+++ b/go/vt/sqlparser/ast_test.go
@@ -570,8 +570,8 @@ func TestReplaceExpr(t *testing.T) {
 		in:  "select * from t where -(select a from b)",
 		out: "-:a",
 	}, {
-		in:  "select * from t where interval (select a from b) aa",
-		out: "interval :a aa",
+		in:  "select * from t where d + interval (select a from b) aa",
+		out: "d + interval :a aa",
 	}, {
 		in:  "select * from t where (select a from b) collate utf8",
 		out: ":a collate utf8",

--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -6459,6 +6459,61 @@ func TestInvalid(t *testing.T) {
 	}
 }
 
+func TestIntervalExpressionSyntax(t *testing.T) {
+	valid := []string{
+		"select date '2024-01-01' + interval 1 day",
+		"select interval 1 day + date '2024-01-01'",
+		"select date '2024-01-01' - interval 1 day",
+		"select date_add('2024-01-01', interval 1 day)",
+		"select date_sub('2024-01-01', interval 1 day)",
+		"select adddate('2024-01-01', interval 1 day)",
+		"select subdate('2024-01-01', interval 1 day)",
+		"select date '2024-01-01' + interval ? day",
+		"select sum(1) over (order by d range interval 1 day preceding) from t",
+		"create event e on schedule at current_timestamp + interval 1 day do select 1",
+	}
+	for _, query := range valid {
+		t.Run(query, func(t *testing.T) {
+			_, err := Parse(query)
+			require.NoError(t, err)
+		})
+	}
+
+	invalid := []string{
+		"select interval 1 day",
+		"select (interval 1 day)",
+		"select interval 1 day as x",
+		"select * from (select interval 1 day) t",
+		"select interval 1 day = interval 1 day",
+		"select date '2024-01-01' + (interval 1 day)",
+		"select (interval 1 day) + date '2024-01-01'",
+		"select interval 1 day + interval 1 day",
+		"select -interval 1 day",
+		"select interval 1 day * 2",
+		"select 2 * interval 1 day",
+		"select interval 1 day - date '2024-01-01'",
+		"select if(true, interval 1 day, 0)",
+		"select cast(interval 1 day as char)",
+		"select mysql.date_add('2024-01-01', interval 1 day)",
+		"select date_add(interval 1 day, interval 1 day)",
+		"select date_add(distinct '2024-01-01', interval 1 day)",
+		"select sum(1) over (order by d range (interval 1 day) preceding) from t",
+		"create event e on schedule at current_timestamp + interval 1 day do select interval 1 day",
+	}
+	for _, query := range invalid {
+		t.Run(query, func(t *testing.T) {
+			_, err := Parse(query)
+			require.ErrorContains(t, err, "syntax error")
+		})
+	}
+
+	tokenizer := NewTokenizer(strings.NewReader("select interval 1 day; select date '2024-01-01' + interval 1 day"))
+	_, err := ParseNext(tokenizer)
+	require.ErrorContains(t, err, "syntax error")
+	_, err = ParseNext(tokenizer)
+	require.NoError(t, err)
+}
+
 func TestCaseSensitivity(t *testing.T) {
 	validSQL := []parseTest{
 		{

--- a/go/vt/sqlparser/sql.go
+++ b/go/vt/sqlparser/sql.go
@@ -23749,13 +23749,13 @@ yydefault:
 		yyDollar = yyS[yypt-3 : yypt+1]
 //line sql.y:9216
 		{
-			yyVAL.val = &BinaryExpr{Left: tryCastExpr(yyDollar[1].val), Operator: PlusStr, Right: tryCastExpr(yyDollar[3].val)}
+			yyVAL.val = newArithmeticExpr(yylex, tryCastExpr(yyDollar[1].val), PlusStr, tryCastExpr(yyDollar[3].val))
 		}
 	case 1525:
 		yyDollar = yyS[yypt-3 : yypt+1]
 //line sql.y:9220
 		{
-			yyVAL.val = &BinaryExpr{Left: tryCastExpr(yyDollar[1].val), Operator: MinusStr, Right: tryCastExpr(yyDollar[3].val)}
+			yyVAL.val = newArithmeticExpr(yylex, tryCastExpr(yyDollar[1].val), MinusStr, tryCastExpr(yyDollar[3].val))
 		}
 	case 1526:
 		yyDollar = yyS[yypt-3 : yypt+1]
@@ -23875,7 +23875,7 @@ yydefault:
 			// as a function. If support is needed for that,
 			// we'll need to revisit this. The solution
 			// will be non-trivial because of grammar conflicts.
-			yyVAL.val = &IntervalExpr{Expr: tryCastExpr(yyDollar[2].val), Unit: yyDollar[3].val.(ColIdent).String()}
+			yyVAL.val = newIntervalExpr(yylex, tryCastExpr(yyDollar[2].val), yyDollar[3].val.(ColIdent).String())
 		}
 	case 1543:
 		yyDollar = yyS[yypt-3 : yypt+1]
@@ -23887,13 +23887,13 @@ yydefault:
 		yyDollar = yyS[yypt-5 : yypt+1]
 //line sql.y:9326
 		{
-			yyVAL.val = &FuncExpr{Name: yyDollar[1].val.(ColIdent), Distinct: yyDollar[3].val.(string) == DistinctStr, Exprs: yyDollar[4].val.(SelectExprs)}
+			yyVAL.val = newGenericFunctionExpr(yylex, TableIdent{}, yyDollar[1].val.(ColIdent), yyDollar[3].val.(string) == DistinctStr, yyDollar[4].val.(SelectExprs))
 		}
 	case 1551:
 		yyDollar = yyS[yypt-6 : yypt+1]
 //line sql.y:9330
 		{
-			yyVAL.val = &FuncExpr{Qualifier: yyDollar[1].val.(TableIdent), Name: yyDollar[3].val.(ColIdent), Exprs: yyDollar[5].val.(SelectExprs)}
+			yyVAL.val = newGenericFunctionExpr(yylex, yyDollar[1].val.(TableIdent), yyDollar[3].val.(ColIdent), false, yyDollar[5].val.(SelectExprs))
 		}
 	case 1552:
 		yyDollar = yyS[yypt-6 : yypt+1]

--- a/go/vt/sqlparser/sql.y
+++ b/go/vt/sqlparser/sql.y
@@ -9214,11 +9214,11 @@ value_expression:
   }
 | value_expression '+' value_expression
   {
-    $$ = &BinaryExpr{Left: tryCastExpr($1), Operator: PlusStr, Right: tryCastExpr($3)}
+    $$ = newArithmeticExpr(yylex, tryCastExpr($1), PlusStr, tryCastExpr($3))
   }
 | value_expression '-' value_expression
   {
-    $$ = &BinaryExpr{Left: tryCastExpr($1), Operator: MinusStr, Right: tryCastExpr($3)}
+    $$ = newArithmeticExpr(yylex, tryCastExpr($1), MinusStr, tryCastExpr($3))
   }
 | value_expression '*' value_expression
   {
@@ -9304,7 +9304,7 @@ value_expression:
     // as a function. If support is needed for that,
     // we'll need to revisit this. The solution
     // will be non-trivial because of grammar conflicts.
-    $$ = &IntervalExpr{Expr: tryCastExpr($2), Unit: $3.(ColIdent).String()}
+    $$ = newIntervalExpr(yylex, tryCastExpr($2), $3.(ColIdent).String())
   }
 | value_expression CONCAT value_expression
   {
@@ -9324,11 +9324,11 @@ value_expression:
 function_call_generic:
   sql_id openb distinct_opt argument_expression_list_opt closeb
   {
-    $$ = &FuncExpr{Name: $1.(ColIdent), Distinct: $3.(string) == DistinctStr, Exprs: $4.(SelectExprs)}
+    $$ = newGenericFunctionExpr(yylex, TableIdent{}, $1.(ColIdent), $3.(string) == DistinctStr, $4.(SelectExprs))
   }
 | table_id '.' reserved_sql_id openb argument_expression_list_opt closeb
   {
-    $$ = &FuncExpr{Qualifier: $1.(TableIdent), Name: $3.(ColIdent), Exprs: $5.(SelectExprs)}
+    $$ = newGenericFunctionExpr(yylex, $1.(TableIdent), $3.(ColIdent), false, $5.(SelectExprs))
   }
 
 /*

--- a/go/vt/sqlparser/token.go
+++ b/go/vt/sqlparser/token.go
@@ -60,6 +60,7 @@ type Tokenizer struct {
 	buf                  []byte
 	lastToken            []byte
 	lastNonNilToken      []byte
+	intervalExprs        map[*IntervalExpr]bool
 	nesting              int
 	bufPos               int
 	bufSize              int
@@ -81,6 +82,32 @@ type Tokenizer struct {
 	SkipSpecialComments  bool
 	AllowComments        bool
 	PipesAsConcat        bool
+}
+
+// registerIntervalExpr records an interval expression for validation after parsing.
+func (tkn *Tokenizer) registerIntervalExpr(expr *IntervalExpr) {
+	if tkn.intervalExprs == nil {
+		tkn.intervalExprs = make(map[*IntervalExpr]bool)
+	}
+	tkn.intervalExprs[expr] = false
+}
+
+// allowIntervalExpr marks an interval expression as occupying a MySQL-compatible syntax position.
+func (tkn *Tokenizer) allowIntervalExpr(expr Expr) {
+	interval, ok := expr.(*IntervalExpr)
+	if ok {
+		tkn.intervalExprs[interval] = true
+	}
+}
+
+// hasInvalidIntervalExpr reports whether parsing produced an interval in an unsupported position.
+func (tkn *Tokenizer) hasInvalidIntervalExpr() bool {
+	for _, valid := range tkn.intervalExprs {
+		if !valid {
+			return true
+		}
+	}
+	return false
 }
 
 var defaultIdQuotes = map[uint16]struct{}{backtickQuote: {}}
@@ -893,6 +920,7 @@ func (tkn *Tokenizer) next() {
 func (tkn *Tokenizer) reset() {
 	tkn.ParseTree = nil
 	tkn.specialComment = nil
+	tkn.intervalExprs = nil
 	tkn.posVarIndex = 0
 	tkn.nesting = 0
 	bufLeft := len(tkn.buf) - tkn.bufPos


### PR DESCRIPTION
Rejects standalone and otherwise invalid INTERVAL expressions after AST construction while preserving MySQL-supported date arithmetic, date functions, window frame bounds, and event schedules. This avoids introducing conflicts into Vitess's flattened expression grammar and prevents invalid interval expressions from reaching execution.

Part of dolthub/dolt#11452